### PR TITLE
Feature: Add copy button to function popups

### DIFF
--- a/src/webview/popups.js
+++ b/src/webview/popups.js
@@ -24,6 +24,9 @@ function showLibDocPopup(d) {
 
 // ── Function source popup — factory pattern ───────────────────────────────────
 
+const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
 function updateSaveBtn(inst) {
   const hasChanges = !inst.textarea.readOnly
     && inst.originalSource !== null
@@ -96,9 +99,6 @@ function createFuncPopupInstance(d) {
   const closeBtn = document.createElement('button');
   closeBtn.title = 'Close';
   closeBtn.innerHTML = '&#x2715;';
-
-  const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
-  const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
 
   const copyBtn = document.createElement('button');
   copyBtn.title = 'Copy Source';

--- a/src/webview/popups.js
+++ b/src/webview/popups.js
@@ -97,8 +97,20 @@ function createFuncPopupInstance(d) {
   closeBtn.title = 'Close';
   closeBtn.innerHTML = '&#x2715;';
 
+  const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+  const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+  const copyBtn = document.createElement('button');
+  copyBtn.title = 'Copy Source';
+  copyBtn.innerHTML = COPY_ICON;
+
+  const actionsContainer = document.createElement('div');
+  actionsContainer.className = 'func-header-actions';
+  actionsContainer.appendChild(copyBtn);
+  actionsContainer.appendChild(closeBtn);
+
   header.appendChild(titleEl);
-  header.appendChild(closeBtn);
+  header.appendChild(actionsContainer);
 
   const body = document.createElement('div');
   body.className = 'func-body';
@@ -178,6 +190,18 @@ function createFuncPopupInstance(d) {
   closeBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     closeFuncPopupInstance(inst);
+  });
+
+  copyBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(textarea.value).then(() => {
+      copyBtn.innerHTML = CHECK_ICON;
+      setTimeout(() => {
+        copyBtn.innerHTML = COPY_ICON;
+      }, 2000);
+    }).catch(err => {
+      console.error('Failed to copy source:', err);
+    });
   });
 
   textarea.addEventListener('input', () => {

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -700,15 +700,23 @@ body.vscode-light {
 }
 .func-header:active { cursor: grabbing; }
 
+.func-header-actions {
+  display: flex;
+  gap: 6px;
+}
+
 .func-header button {
   background: none;
   border: none;
   color: var(--vscode-editor-foreground, #cccccc);
   cursor: pointer;
   font-size: 14px;
-  padding: 2px 4px;
+  padding: 4px;
   border-radius: 3px;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .func-header button:hover {
   background: var(--vscode-toolbar-hoverBackground, #333);


### PR DESCRIPTION
This PR improves UX by adding a small "Copy" button to the header of the Function Source Popups. 

### Changes Made
* Added a `copyBtn` DOM element to `src/webview/popups.js` within the `createFuncPopupInstance` header.
* Wrapped both the copy and close buttons in a `.func-header-actions` flex container for proper spacing in `src/webview/styles.css`.
* Included explicit `.catch()` error handling for the async clipboard write

The copy and the tick icon looks kinda sick ngl