### PR TITLE
Feature: Add Ctrl+F / Cmd+F Keyboard Support for Graph Search

### DIFF
--- a/src/webview/controls.js
+++ b/src/webview/controls.js
@@ -271,10 +271,17 @@ document.getElementById('lib-doc-goto-btn')?.addEventListener('click', () => {
 
 // ── Function popup — Escape closes topmost ────────────────────────────────────
 document.addEventListener('keydown', (e) => {
+  // 1. Close topmost function popup on Escape
   if (e.key === 'Escape' && state.funcPopups.size > 0) {
     const top = [...state.funcPopups.values()].reduce((a, b) =>
       parseInt(b.element.style.zIndex) > parseInt(a.element.style.zIndex) ? b : a);
     closeFuncPopupInstance(top);
+  }
+
+  // 2. Focus search on Ctrl+F or Cmd+F
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f') {
+    e.preventDefault();
+    document.getElementById('search')?.focus();
   }
 });
 


### PR DESCRIPTION
1. Open the Settings Panel: In the opened CoGraph tab, click the Settings button (it looks like a gear icon ⚙️) to open the side panel. You should now see the "Filter functions..." input box

2. Click the Background (Focus the Webview): Click anywhere on the dark, empty background behind the graph nodes. 

3. Press Ctrl+F:

4. See the result: You will instantly see a blue focus ring outline appear around the "Filter functions..." box, and your typing cursor will start blinking inside it. If you start typing, text will appear in the box.