### PR TITLE
ci(dependabot): ignore @types/vscode, @types/node majors, eslint majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # vsce refuses to package @types/vscode newer than engines.vscode (^1.75):
+      # bump this only together with a deliberate engines.vscode raise (see PR #44).
+      - dependency-name: "@types/vscode"
+      # Keep node types on the runtime major used by CI and engines (Node 20) —
+      # newer-major types allow APIs that don't exist at runtime (see PR #46).
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # eslint 9+ requires flat config + typescript-eslint v8; take majors only
+      # as a dedicated migration (see PR #47).
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
 


### PR DESCRIPTION
Encodes the outcomes of the first dependabot wave (#43–#48) so the same rejected bumps don't reopen weekly:

- **@types/vscode** — any version above `engines.vscode` (^1.75) fails `vsce package` (#44); bump only together with a deliberate engines raise.
- **@types/node majors** — stay on the CI/engines runtime major, Node 20 (#46).
- **eslint majors** — eslint 9+ requires flat config + typescript-eslint v8; that's a dedicated migration, not an auto-bump (#47).

Merged as-is this week: actions group (#43), glob 13 (#48), typescript 6 (#45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)