### PR TITLE
build: bundle the extension with esbuild (1400 -> 38 packaged files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 out/
+dist/
 prompts/
 .vscode/
 .vscode-test/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,28 +1,36 @@
 .vscode/**
+.vscode-test/**
 .ai/**
 .claude/**
+.cograph/**
 .github/**
+docs/**
 prompts/**
+
+# The packaged runtime is dist/** (esbuild bundles — see esbuild.js). The
+# webview ships as plain JS straight from src/webview; everything else in
+# src/ and the tsc output in out/ stay out of the .vsix.
 src/**
 !src/webview/**
-scripts/__pycache__/**
-scripts/test_*.py
+out/**
+
+# Node analyzer sources are bundled into dist/scripts (with both .wasm files
+# next to them). Only the Python analyzers run from scripts/ in the package.
+scripts/**
+!scripts/analyze.py
+!scripts/describe_lib.py
+
+# All runtime dependencies are inlined by esbuild.
+node_modules/**
+
 **/*.ts
+**/*.map
 **/*.swp
 **/*.tmp
-out/test/**
-out/**/*.test.js
-out/**/*.test.js.map
-node_modules/**
-!node_modules/typescript/**
-!node_modules/web-tree-sitter/**
-# java-parser + its (hoisted) transitive deps — required by scripts/analyze_java.js
-!node_modules/java-parser/**
-!node_modules/chevrotain/**
-!node_modules/regexp-to-ast/**
-!node_modules/lodash/**
 .eslintrc.json
+.gitignore
 tsconfig.json
+esbuild.js
 .pytest_cache/**
 requirements-dev.txt
 CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,11 @@ microservice ceremony.
 git clone https://github.com/thraenbe/cograph.git
 cd cograph
 npm ci
-npm run watch        # incremental TypeScript compile in the background
+npm run bundle:watch # incremental esbuild bundle to ./dist — this is what the dev host runs
 ```
+
+`npm run watch` (incremental `tsc` to `./out`) is still useful alongside it: esbuild
+does not type-check, so tsc is where type errors surface.
 
 To launch the extension in a development host:
 
@@ -33,7 +36,8 @@ To launch the extension in a development host:
 ## Build, lint, and test
 
 ```bash
-npm run compile      # one-off TypeScript build to ./out
+npm run compile      # one-off type-checking TypeScript build to ./out (tests run from here)
+npm run bundle       # one-off esbuild bundle to ./dist (VS Code runs the extension from here)
 npm run lint         # ESLint over src/**/*.ts
 npm test             # Mocha suite via @vscode/test-electron (downloads VS Code)
 npm run package      # produce a .vsix (sanity-check packaging)

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,0 +1,73 @@
+// esbuild.js — production bundling for vsce packaging.
+//
+// The packaged extension runs entirely from dist/: the extension host bundle
+// (dist/extension.js) and one self-contained bundle per node analyzer
+// subprocess (dist/scripts/analyze_*.js), so no node_modules ship in the
+// .vsix. Tests and lint keep using tsc output in out/ — analyzerRunner falls
+// back to the scripts/ sources whenever dist/ is absent.
+//
+// Usage: node esbuild.js [--production] [--watch]
+
+const esbuild = require('esbuild');
+const fs = require('fs');
+const path = require('path');
+
+const production = process.argv.includes('--production');
+const watch = process.argv.includes('--watch');
+
+// VS Code engine floor is 1.75, which ships a Node 16 extension host.
+const common = {
+  bundle: true,
+  platform: 'node',
+  target: 'node16',
+  format: 'cjs',
+  minify: production,
+  sourcemap: !production,
+  logLevel: 'info',
+};
+
+async function main() {
+  // `vscode` is provided by the extension host at runtime.
+  const extension = await esbuild.context({
+    ...common,
+    entryPoints: ['src/extension.ts'],
+    outfile: 'dist/extension.js',
+    external: ['vscode'],
+  });
+
+  // Analyzer subprocesses (spawned via child_process, so they need their
+  // dependencies — typescript, java-parser, web-tree-sitter — inlined).
+  const analyzers = await esbuild.context({
+    ...common,
+    entryPoints: [
+      'scripts/analyze_ts.js',
+      'scripts/analyze_js.js',
+      'scripts/analyze_java.js',
+      'scripts/analyze_cpp.js',
+    ],
+    outdir: 'dist/scripts',
+  });
+
+  // Both WASM files are resolved relative to __dirname at runtime:
+  // tree-sitter-cpp.wasm by scripts/analyze_cpp.js, web-tree-sitter.wasm by
+  // web-tree-sitter's Emscripten loader (scriptDirectory = __dirname).
+  fs.mkdirSync(path.join(__dirname, 'dist', 'scripts'), { recursive: true });
+  for (const [src, dest] of [
+    ['scripts/tree-sitter-cpp.wasm', 'dist/scripts/tree-sitter-cpp.wasm'],
+    ['node_modules/web-tree-sitter/web-tree-sitter.wasm', 'dist/scripts/web-tree-sitter.wasm'],
+  ]) {
+    fs.copyFileSync(path.join(__dirname, src), path.join(__dirname, dest));
+  }
+
+  if (watch) {
+    await Promise.all([extension.watch(), analyzers.watch()]);
+  } else {
+    await Promise.all([extension.rebuild(), analyzers.rebuild()]);
+    await Promise.all([extension.dispose(), analyzers.dispose()]);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@typescript-eslint/parser": "^6.0.0",
         "@vscode/test-electron": "^2.3.0",
         "@vscode/vsce": "^2.32.0",
+        "esbuild": "^0.28.1",
         "eslint": "^8.0.0",
         "glob": "^13.0.6",
         "jsdom": "^25.0.1",
@@ -311,6 +312,448 @@
           "type": "opencollective",
           "url": "https://opencollective.com/csstools"
         }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -2074,6 +2517,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "onCommand:cograph.saveGraphAs",
     "onView:cograph.savedGraphs"
   ],
-  "main": "./out/extension.js",
+  "main": "./dist/extension.js",
   "contributes": {
     "viewsContainers": {
       "activitybar": [
@@ -201,10 +201,12 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "node esbuild.js --production",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile",
+    "bundle": "node esbuild.js",
+    "bundle:watch": "node esbuild.js --watch",
+    "pretest": "npm run compile && npm run bundle",
     "test": "node ./out/test/runTest.js",
     "lint": "eslint src --ext ts",
     "build:cpp-grammar": "tree-sitter build --wasm node_modules/tree-sitter-cpp -o scripts/tree-sitter-cpp.wasm",
@@ -226,6 +228,7 @@
     "@typescript-eslint/parser": "^6.0.0",
     "@vscode/test-electron": "^2.3.0",
     "@vscode/vsce": "^2.32.0",
+    "esbuild": "^0.28.1",
     "eslint": "^8.0.0",
     "glob": "^13.0.6",
     "jsdom": "^25.0.1",

--- a/scripts/analyze_java.js
+++ b/scripts/analyze_java.js
@@ -15,8 +15,9 @@
 
 const path = require('path');
 const fs   = require('fs');
-const { parse, BaseJavaCstVisitorWithDefaults } =
-  require(path.join(__dirname, '..', 'node_modules', 'java-parser'));
+// Bare specifier so esbuild can inline it into the packaged bundle (dev runs
+// resolve it from the repo's node_modules via normal module resolution).
+const { parse, BaseJavaCstVisitorWithDefaults } = require('java-parser');
 
 const SKIP_DIR_NAMES = new Set(['node_modules', 'out', 'dist', 'target', 'build']);
 

--- a/scripts/analyze_js.js
+++ b/scripts/analyze_js.js
@@ -14,7 +14,9 @@
 
 const path = require('path');
 const fs   = require('fs');
-const ts   = require(path.join(__dirname, '..', 'node_modules', 'typescript'));
+// Bare specifier so esbuild can inline it into the packaged bundle (dev runs
+// resolve it from the repo's node_modules via normal module resolution).
+const ts   = require('typescript');
 
 const SKIP_DIR_NAMES = new Set(['node_modules', 'out', 'dist']);
 const JS_EXTENSIONS  = new Set(['.js', '.jsx', '.mjs', '.cjs']);

--- a/scripts/analyze_ts.js
+++ b/scripts/analyze_ts.js
@@ -13,7 +13,9 @@
 
 const path = require('path');
 const fs   = require('fs');
-const ts   = require(path.join(__dirname, '..', 'node_modules', 'typescript'));
+// Bare specifier so esbuild can inline it into the packaged bundle (dev runs
+// resolve it from the repo's node_modules via normal module resolution).
+const ts   = require('typescript');
 
 const SKIP_DIR_NAMES = new Set(['node_modules', 'out', 'dist']);
 

--- a/src/analyzerRunner.ts
+++ b/src/analyzerRunner.ts
@@ -133,14 +133,24 @@ export class AnalyzerRunner {
     this.onResult(JSON.stringify(merged), workspaceRoot, { statuses, candidateFilesFound });
   }
 
+  /**
+   * Absolute path to an analyzer subprocess script. Packaged builds ship
+   * esbuild-bundled node analyzers under dist/scripts (self-contained, no
+   * node_modules in the .vsix); dev and test hosts fall back to the sources
+   * under scripts/. The Python analyzers only ever exist under scripts/.
+   */
+  private analyzerScript(name: string): string {
+    const bundled = path.join(this.context.extensionPath, 'dist', 'scripts', name);
+    return fs.existsSync(bundled) ? bundled : path.join(this.context.extensionPath, 'scripts', name);
+  }
+
   private runOnce(workspaceRoot: string, pythonBin: string): Promise<{ merged: GraphData; statuses: AnalyzerResult[] }> {
-    const ext = this.context.extensionPath;
     const spawns: Array<Promise<AnalyzerResult>> = [
-      this.spawnAnalyzerProcess(pythonBin, [path.join(ext, 'scripts', 'analyze.py'), workspaceRoot], 'python'),
-      this.spawnAnalyzerProcess(process.execPath, [path.join(ext, 'scripts', 'analyze_ts.js'), workspaceRoot], 'typescript'),
-      this.spawnAnalyzerProcess(process.execPath, [path.join(ext, 'scripts', 'analyze_js.js'), workspaceRoot], 'javascript'),
-      this.spawnAnalyzerProcess(process.execPath, [path.join(ext, 'scripts', 'analyze_java.js'), workspaceRoot], 'java'),
-      this.spawnAnalyzerProcess(process.execPath, [path.join(ext, 'scripts', 'analyze_cpp.js'), workspaceRoot], 'cpp'),
+      this.spawnAnalyzerProcess(pythonBin, [this.analyzerScript('analyze.py'), workspaceRoot], 'python'),
+      this.spawnAnalyzerProcess(process.execPath, [this.analyzerScript('analyze_ts.js'), workspaceRoot], 'typescript'),
+      this.spawnAnalyzerProcess(process.execPath, [this.analyzerScript('analyze_js.js'), workspaceRoot], 'javascript'),
+      this.spawnAnalyzerProcess(process.execPath, [this.analyzerScript('analyze_java.js'), workspaceRoot], 'java'),
+      this.spawnAnalyzerProcess(process.execPath, [this.analyzerScript('analyze_cpp.js'), workspaceRoot], 'cpp'),
     ];
     return Promise.all(spawns).then((statuses) => {
       const merged: GraphData = {
@@ -175,8 +185,7 @@ export class AnalyzerRunner {
     }
 
     try {
-      const ext = this.context.extensionPath;
-      const withList = (script: string) => [path.join(ext, 'scripts', script), workspaceRoot, '--files', listPath];
+      const withList = (script: string) => [this.analyzerScript(script), workspaceRoot, '--files', listPath];
       const spawns: Array<Promise<AnalyzerResult>> = [
         this.spawnAnalyzerProcess(process.execPath, withList('analyze_ts.js'), 'typescript'),
         this.spawnAnalyzerProcess(process.execPath, withList('analyze_js.js'), 'javascript'),


### PR DESCRIPTION
## Problem

Every `vsce package` warns:

> This extension consists of 1400 files, out of which 1212 are JavaScript files. For performance reasons, you should bundle your extension.

The .vsix shipped `node_modules/typescript`, `java-parser`, `chevrotain`, `lodash`, `regexp-to-ast` and `web-tree-sitter` wholesale because the analyzer subprocesses loaded them at runtime via `require(path.join(__dirname, '..', 'node_modules', ...))`.

## Change

The package now runs entirely from esbuild bundles — no `node_modules` in the .vsix:

- **`esbuild.js`** builds `dist/extension.js` (extension host, `vscode` external) and one self-contained bundle per node analyzer under `dist/scripts/`, copying `tree-sitter-cpp.wasm` + `web-tree-sitter.wasm` next to them (both resolved via `__dirname` at runtime).
- **Analyzers** require their deps by bare specifier so esbuild can inline them; dev runs resolve identically through normal module resolution.
- **`analyzerRunner`** prefers `dist/scripts/<analyzer>` when present (packaged build) and falls back to `scripts/` (dev/test). Python analyzers always run from `scripts/`.
- **`package.json`**: `main` → `dist/extension.js`; `vscode:prepublish` produces the minified production bundle; new `bundle` / `bundle:watch` scripts; `pretest` also bundles so the dev/test host always finds `main`.
- **`.vscodeignore`** rewritten: node_modules whitelists dropped; `src/` (except the webview, which ships as plain JS), `out/`, `docs/`, analyzer sources excluded.
- **CONTRIBUTING** updated: the dev host now runs `dist/`, so `bundle:watch` is the dev loop; `tsc` remains the type-checker.

## Result

`cograph-1.1.1.vsix`: **1400 files → 38 files (2.52 MB)**, warning gone.

## Verification

- `npm test`: 654 passing (pretest now compiles **and** bundles).
- Each bundled analyzer smoke-tested as a standalone subprocess against ts/js/java/cpp fixtures → correct nodes/edges, including the C++ WASM loading from `dist/scripts`.
- `npm run package` file inventory reviewed (tree in the packaging output).
- CI runs `npm run package` on all three OSes on this PR.

## Note for the dev loop

After this merges, an existing dev checkout needs one `npm run bundle` (or `bundle:watch`) before F5 — `npm run watch` alone no longer feeds the dev host.
