### PR TITLE
Fix force-directed layout performance for large repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Large graphs (≥800 rendered nodes) now settle and freeze instead of simulating indefinitely; dragging a node moves it directly without reheating the whole graph.
+- Force defaults now scale with repository size, and the Reset Layout button restores size-appropriate values.
+- Workflow view detail is clamped so huge repositories never render an unbounded node count.
+- The CoGraph output channel now logs per-analyzer wall time, payload size, and webview layout settle time.
+
+### Fixed
+- The initial center force (0.025) now matches the slider and reset default (0.05).
+
 ## [1.1.1] - 2026-07-03
 
 ### Fixed

--- a/docs/superpowers/plans/2026-07-06-large-repo-force-layout-perf.md
+++ b/docs/superpowers/plans/2026-07-06-large-repo-force-layout-perf.md
@@ -1,0 +1,674 @@
+# Large-Repo Force Layout Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve GitHub issue #52 (force layout jank on large repos), issue #27 (dynamic per-repo force defaults), and issue #50 Approach 3.1 (perf instrumentation), on branch `perf/large-repo-force-layout` off `origin/main`.
+
+**Architecture:** All new decision logic lives in a new pure module `src/webview/layoutTuning.js` (browser-global + guarded CJS export, same pattern as `aggregate.js`) so it is unit-testable — `rendering.js` cannot be `require()`d (it touches d3/DOM at module load), so its edits stay thin wiring. Instrumentation goes through the existing `CoGraph` OutputChannel via the already-injected `log` callback (extension side) and a new `layout-metrics` webview→host message.
+
+**Tech Stack:** VS Code extension (TS, `tsc` → `out/`, esbuild → `dist/`), webview in plain JS with d3 v7 (CDN), tests via `@vscode/test-electron` + mocha **TDD interface** (`suite`/`test`/`setup`/`teardown`) + node `assert` + `sinon`, jsdom for DOM tests.
+
+## Global Constraints
+
+- **Windows quirk:** node is not on PATH. Every npm command: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test` (PowerShell).
+- **Run tests with:** `npm test` (pretest runs `compile` + `bundle`; suite ~650 tests, VS Code 1.116.0 already cached in `.vscode-test`).
+- **Small-graph invariance (issue #52 acceptance):** graphs below the large-graph threshold must behave exactly as today, except the deliberate `centerForce` init fix (0.025 → 0.05, reconciling main.js:41 vs controls.js:71/webviewHtmlBuilder.ts:347).
+- **Test discovery:** new `src/test/suite/*.test.ts` files are auto-discovered (glob over compiled `out/test/suite/**/*.test.js`). Webview modules are required directly from source: `require('../../../src/webview/<file>.js')`.
+- **Shared-global gotcha:** webview modules read globals (`state`, `settings`); tests must save in `setup()` and restore in `teardown()` (pattern: `drilldown.test.ts:35-38`).
+- Coding standards: camelCase, files < 400 LOC, functions < 50 LOC, explicit error handling, no `console.log`.
+- Never delete files. No scope expansion beyond this plan.
+- Commit after every task (conventional commits: `feat:`/`fix:`/`test:`/`chore:`).
+
+## File Structure
+
+- **Create** `src/webview/layoutTuning.js` — all size-based tuning decisions (pure, ~80 LOC).
+- **Create** `src/test/suite/layoutTuning.test.ts` — unit tests for the above.
+- **Modify** `src/webviewHtmlBuilder.ts` — add `<script>` tag for layoutTuning.js (before rendering.js).
+- **Modify** `src/webview/rendering.js` — size-aware sim build, settle-freeze, drag policy, `postLayoutMetrics`.
+- **Modify** `src/webview/main.js` — centerForce init fix, `userTunedForces` flag, layout timing start, workflow clamp call.
+- **Modify** `src/webview/folder.js`, `src/webview/class.js` — gate drag reheats.
+- **Modify** `src/webview/controls.js` — `syncForceSliders`, userTuned flag on force-slider input, size-aware reset.
+- **Modify** `src/webview/workflow.js` — `clampWorkflowLevel`.
+- **Modify** `src/webview/state.js` — `layoutStartedAt` field.
+- **Modify** `src/analyzerRunner.ts` — per-analyzer `durationMs` + `[perf]` log lines.
+- **Modify** `src/graphProvider.ts` — payload metrics log + `layout-metrics` message handler.
+- **Modify** tests: `webviewControls.test.ts`, `workflowDerive.test.ts`, `analyzerRunner.test.ts`, `graphProvider.test.ts`.
+- **Modify** `CHANGELOG.md`.
+
+---
+
+### Task 1: `layoutTuning.js` pure module
+
+**Files:**
+- Create: `src/webview/layoutTuning.js`
+- Create: `src/test/suite/layoutTuning.test.ts`
+- Modify: `src/webviewHtmlBuilder.ts` (script tag list, ~lines 200-215 — insert **before** the rendering.js tag)
+
+**Interfaces (Produces — later tasks call these as webview globals):**
+- `isLargeGraph(nodeCount: number): boolean`
+- `computeForceDefaults(nodeCount: number): { centerForce: number, repelForce: number, linkForce: number }`
+- `alphaDecayFor(nodeCount: number): number`
+- `useCollide(nodeCount: number): boolean`
+- `dragShouldReheat(nodeCount: number): boolean`
+- `shouldFreeze(alpha: number, nodeCount: number): boolean`
+- Constants: `LARGE_GRAPH_NODE_THRESHOLD` (800), `WORKFLOW_MAX_NODES` (400)
+
+- [ ] **Step 1: Write the failing test** — `src/test/suite/layoutTuning.test.ts`:
+
+```ts
+import * as assert from 'assert';
+
+// Pure module, guarded CJS export (same pattern as aggregate.js).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tuning = require('../../../src/webview/layoutTuning.js');
+
+suite('layoutTuning', () => {
+  suite('computeForceDefaults', () => {
+    test('small graphs keep the current defaults', () => {
+      for (const n of [0, 10, 250, 499]) {
+        assert.deepStrictEqual(tuning.computeForceDefaults(n),
+          { centerForce: 0.05, repelForce: 250, linkForce: 1 });
+      }
+    });
+    test('very large graphs get compact params (strong center, weak repel)', () => {
+      const d = tuning.computeForceDefaults(3000);
+      assert.strictEqual(d.centerForce, 0.15);
+      assert.strictEqual(d.repelForce, 80);
+      assert.strictEqual(d.linkForce, 1);
+      // clamped beyond the scale window
+      assert.deepStrictEqual(tuning.computeForceDefaults(50000), d);
+    });
+    test('scales monotonically between 500 and 3000 nodes', () => {
+      let prevCenter = 0;
+      let prevRepel = Infinity;
+      for (const n of [500, 1000, 1750, 2500, 3000]) {
+        const d = tuning.computeForceDefaults(n);
+        assert.ok(d.centerForce >= prevCenter, `centerForce non-decreasing at ${n}`);
+        assert.ok(d.repelForce <= prevRepel, `repelForce non-increasing at ${n}`);
+        prevCenter = d.centerForce;
+        prevRepel = d.repelForce;
+      }
+    });
+  });
+
+  suite('size thresholds', () => {
+    test('large-graph boundary at 800 nodes', () => {
+      assert.strictEqual(tuning.isLargeGraph(799), false);
+      assert.strictEqual(tuning.isLargeGraph(800), true);
+      assert.strictEqual(tuning.LARGE_GRAPH_NODE_THRESHOLD, 800);
+    });
+    test('collide and drag-reheat stay on for small graphs, off for large', () => {
+      assert.strictEqual(tuning.useCollide(799), true);
+      assert.strictEqual(tuning.useCollide(800), false);
+      assert.strictEqual(tuning.dragShouldReheat(799), true);
+      assert.strictEqual(tuning.dragShouldReheat(800), false);
+    });
+    test('alphaDecay unchanged for small graphs, faster for large', () => {
+      assert.strictEqual(tuning.alphaDecayFor(799), 0.02);
+      assert.strictEqual(tuning.alphaDecayFor(800), 0.05);
+    });
+  });
+
+  suite('shouldFreeze', () => {
+    test('never freezes small graphs', () => {
+      assert.strictEqual(tuning.shouldFreeze(0.001, 799), false);
+    });
+    test('freezes large graphs only once alpha settles below 0.05', () => {
+      assert.strictEqual(tuning.shouldFreeze(0.06, 800), false);
+      assert.strictEqual(tuning.shouldFreeze(0.049, 800), true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: FAIL — `Cannot find module '../../../src/webview/layoutTuning.js'`
+
+- [ ] **Step 3: Implement** — `src/webview/layoutTuning.js`:
+
+```js
+// Pure size-based tuning decisions for the force layout (issues #52, #27).
+// No DOM, no d3 — keep it require()-able from Node tests (see aggregate.js).
+
+// Above this rendered-node count the simulation gets the "large graph"
+// treatment: faster settle, no collide force, no global reheat on drag.
+const LARGE_GRAPH_NODE_THRESHOLD = 800;
+// computeForceDefaults interpolates between these two sizes.
+const FORCE_SCALE_MIN_NODES = 500;
+const FORCE_SCALE_MAX_NODES = 3000;
+// Large graphs stop simulating below this alpha (d3 default alphaMin is
+// 0.001 — stopping at 0.05 saves the long low-energy tail of ticks).
+const SETTLE_ALPHA_LARGE = 0.05;
+const ALPHA_DECAY_SMALL = 0.02; // current value in startSimulation
+const ALPHA_DECAY_LARGE = 0.05;
+// Cap on rendered workflow-view nodes (issue #52 item 2).
+const WORKFLOW_MAX_NODES = 400;
+
+function isLargeGraph(nodeCount) {
+  return nodeCount >= LARGE_GRAPH_NODE_THRESHOLD;
+}
+
+// Dynamic per-repo force defaults (issue #27): small graphs keep today's
+// values; large graphs get stronger centering and weaker repel so the
+// layout stays compact instead of exploding.
+function computeForceDefaults(nodeCount) {
+  const span = FORCE_SCALE_MAX_NODES - FORCE_SCALE_MIN_NODES;
+  const t = Math.max(0, Math.min(1, (nodeCount - FORCE_SCALE_MIN_NODES) / span));
+  return {
+    centerForce: Math.round((0.05 + t * 0.10) * 1000) / 1000,
+    repelForce: Math.round(250 - t * 170),
+    linkForce: 1,
+  };
+}
+
+function alphaDecayFor(nodeCount) {
+  return isLargeGraph(nodeCount) ? ALPHA_DECAY_LARGE : ALPHA_DECAY_SMALL;
+}
+
+function useCollide(nodeCount) {
+  return !isLargeGraph(nodeCount);
+}
+
+function dragShouldReheat(nodeCount) {
+  return !isLargeGraph(nodeCount);
+}
+
+function shouldFreeze(alpha, nodeCount) {
+  return isLargeGraph(nodeCount) && alpha < SETTLE_ALPHA_LARGE;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    LARGE_GRAPH_NODE_THRESHOLD,
+    WORKFLOW_MAX_NODES,
+    isLargeGraph,
+    computeForceDefaults,
+    alphaDecayFor,
+    useCollide,
+    dragShouldReheat,
+    shouldFreeze,
+  };
+}
+```
+
+Then in `src/webviewHtmlBuilder.ts`, find the block of webview `<script>` tags (state, aggregate, clustering, workflow, highlight, rendering, …) and add a tag for `layoutTuning.js` **immediately after the `state.js` tag** (must load before rendering.js/folder.js/class.js/controls.js). Copy the exact tag syntax (nonce, `webview.asWebviewUri`) of the neighboring `state.js` line.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: PASS (all suites; new `layoutTuning` suite green)
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/webview/layoutTuning.js src/test/suite/layoutTuning.test.ts src/webviewHtmlBuilder.ts
+git commit -m "feat(webview): add layoutTuning module with size-based force defaults"
+```
+
+---
+
+### Task 2: Size-aware simulation build + settle-and-freeze
+
+**Files:**
+- Modify: `src/webview/rendering.js` (`startSimulation` lines ~561-581; `ticked` lines ~274-278)
+- Modify: `src/webview/main.js` (line 41, `centerForce: 0.025`)
+
+**Interfaces:**
+- Consumes: `alphaDecayFor`, `useCollide`, `shouldFreeze` (Task 1 globals).
+- Produces: no new API. Behavior: large graphs settle fast and freeze; small graphs unchanged.
+
+- [ ] **Step 1: Fix the centerForce init inconsistency** — `src/webview/main.js:41`: change `centerForce: 0.025,` to `centerForce: 0.05,` (matches the reset default at controls.js:71 and the slider default at webviewHtmlBuilder.ts:347).
+
+- [ ] **Step 2: Wire size-aware build** — in `startSimulation` full-build path (rendering.js:561-581), with `const n = state.currentNodes.length;` at the top of the build:
+  - Replace `.force('collision', d3.forceCollide(d => nodeRadius(d) + 1))` with a conditional applied after the chain:
+    ```js
+    if (useCollide(n)) {
+      state.simulation.force('collision', d3.forceCollide(d => nodeRadius(d) + 1));
+    }
+    ```
+    (d3 chaining note: build the simulation as today minus `.force('collision', …)`, then apply the conditional force — `simulation.force()` after construction is the idiomatic d3 way.)
+  - Replace `.alphaDecay(0.02)` with `.alphaDecay(alphaDecayFor(n))`.
+
+- [ ] **Step 3: Settle-and-freeze** — in `ticked()` (rendering.js:274-278), extend the existing auto-fit block:
+
+```js
+if (state.simulation) {
+  const alpha = state.simulation.alpha();
+  if (!state.hasFitted && alpha < 0.1) {
+    state.hasFitted = true;
+    fitToView();
+  }
+  if (shouldFreeze(alpha, state.currentNodes.length)) {
+    state.simulation.stop();
+  }
+}
+```
+
+(Preserve the existing `!state.hasFitted && state.simulation` semantics — only restructure to share the `alpha` read. Reheat paths — `rerunLayout` `alpha(0.5).restart()`, `pendingReheat` `alpha(0.1).restart()`, `graph-loaded` — all call `.restart()`, which resumes a stopped simulation, so freezing is always recoverable.)
+
+- [ ] **Step 4: Run full suite**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: PASS — no regressions (rendering.js has no direct unit tests; the decision functions were tested in Task 1).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/webview/rendering.js src/webview/main.js
+git commit -m "feat(webview): settle-and-freeze large graphs, size-aware collide/alphaDecay (#52)"
+```
+
+---
+
+### Task 3: Drag without global reheat on large graphs
+
+**Files:**
+- Modify: `src/webview/rendering.js` (drag handlers, lines ~206-231)
+- Modify: `src/webview/folder.js` (drag reheats at lines ~622/654, 667/681, 705/722, 859/874)
+- Modify: `src/webview/class.js` (drag reheats at lines ~158/172, 191/208)
+
+**Interfaces:**
+- Consumes: `dragShouldReheat` (Task 1 global), global `ticked()` from rendering.js.
+- Produces: no new API. Behavior: on large graphs, dragging pins and moves the dragged node(s) directly (exactly like the existing `static` layout-mode branch) instead of reheating the whole simulation.
+
+**IMPORTANT for the implementer:** read each drag handler in full before editing — folder.js/class.js handlers move *groups* of member nodes; mirror the same fx/fy updates into x/y in no-reheat mode. Line numbers are anchors, not gospel.
+
+- [ ] **Step 1: rendering.js node drag** — apply this transformation to the `d3.drag()` handlers (lines 206-231):
+
+```js
+// start (was: if (state.layoutMode === 'dynamic' && !event.active && state.simulation) state.simulation.alphaTarget(0.3).restart();)
+const reheat = dragShouldReheat(state.currentNodes.length);
+if (state.layoutMode === 'dynamic' && reheat && !event.active && state.simulation) {
+  state.simulation.alphaTarget(0.3).restart();
+}
+// (keep: d.fx = d.x; d.fy = d.y;)
+
+// drag move: extend the existing static branch condition
+// (was: if (state.layoutMode === 'static') { d.x = event.x; d.y = event.y; ticked(); })
+if (state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length)) {
+  d.x = event.x;
+  d.y = event.y;
+  ticked();
+}
+
+// end: only the reheat path cools down and releases the pin; the
+// no-reheat path keeps fx/fy pinned (issue #52: "fix that node").
+if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
+  if (!event.active && state.simulation) state.simulation.alphaTarget(0);
+  d.fx = null;
+  d.fy = null;
+}
+// (keep the existing window.markDirty?.() call)
+```
+
+- [ ] **Step 2: folder.js and class.js** — for each of the six group-drag handlers, apply the same gate:
+  - Every `state.simulation.alphaTarget(0.3).restart()` (start) becomes conditional on `dragShouldReheat(state.currentNodes.length)`.
+  - Every matching `state.simulation.alphaTarget(0)` (end) gets the same condition.
+  - In each **drag-move** handler, after the member nodes' `fx`/`fy` are updated, add:
+    ```js
+    if (!dragShouldReheat(state.currentNodes.length)) {
+      // simulation is frozen — apply positions directly and repaint once
+      for (const node of movedNodes) { node.x = node.fx; node.y = node.fy; }
+      ticked();
+    }
+    ```
+    where `movedNodes` is whatever collection that specific handler already iterates (read the handler; reuse its own variable).
+
+- [ ] **Step 3: Run full suite**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: PASS (drilldown.test.ts exercises folder.js's pure force functions — they must be untouched).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add src/webview/rendering.js src/webview/folder.js src/webview/class.js
+git commit -m "feat(webview): drag moves nodes directly on large graphs instead of reheating (#52)"
+```
+
+---
+
+### Task 4: Apply dynamic force defaults + slider sync + reset consistency (#27)
+
+**Files:**
+- Modify: `src/webview/main.js` (settings object ~lines 30-48: add `userTunedForces: false`)
+- Modify: `src/webview/controls.js` (wireSlider call sites ~114-123; reset handler ~66-74; new `syncForceSliders`)
+- Modify: `src/webview/rendering.js` (`startSimulation` full-build path)
+- Test: `src/test/suite/webviewControls.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `computeForceDefaults` (Task 1).
+- Produces: `syncForceSliders()` (controls.js global — updates the three force sliders + value labels from `settings`); `settings.userTunedForces: boolean`.
+
+- [ ] **Step 1: Write the failing tests** — extend `src/test/suite/webviewControls.test.ts` (follow its existing jsdom setup — DOM + globals installed *before* `require('.../controls.js')`; the DOM builder must contain `#slider-center-force`, `#slider-repel-force`, `#slider-link-force` and their value-label elements — read the existing `makeDOM` helper and the `wireSlider(id, valId, …)` call sites for the exact label ids, and extend `makeDOM` if any are missing):
+
+```ts
+suite('dynamic force defaults (#27)', () => {
+  test('force slider input marks settings.userTunedForces', () => {
+    (global as any).settings.userTunedForces = false;
+    const slider = dom.window.document.getElementById('slider-repel-force') as any;
+    slider.value = '300';
+    dispatch(slider, 'input');
+    assert.strictEqual((global as any).settings.userTunedForces, true);
+  });
+
+  test('syncForceSliders pushes settings values into sliders and labels', () => {
+    (global as any).settings.centerForce = 0.15;
+    (global as any).settings.repelForce = 80;
+    (global as any).settings.linkForce = 1;
+    (global as any).syncForceSliders();
+    const slider = dom.window.document.getElementById('slider-repel-force') as any;
+    assert.strictEqual(slider.value, '80');
+  });
+
+  test('reset restores size-based defaults and clears userTunedForces', () => {
+    (global as any).state.currentNodes = new Array(3000).fill(0).map((_, i) => ({ id: String(i) }));
+    (global as any).settings.userTunedForces = true;
+    (global as any).settings.repelForce = 999;
+    const btn = dom.window.document.getElementById('btn-reset-layout') as any; // read controls.js for the real reset control id
+    dispatch(btn, 'click');
+    assert.strictEqual((global as any).settings.repelForce, 80);
+    assert.strictEqual((global as any).settings.userTunedForces, false);
+  });
+});
+```
+
+(The reset control's element id and event must be read from controls.js:66-74 and mirrored exactly — adjust the test to the real trigger. `computeForceDefaults` must be installed as a jsdom global in this suite's setup: `(global as any).computeForceDefaults = require('../../../src/webview/layoutTuning.js').computeForceDefaults;` — in the real webview it's a shared script global.)
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: FAIL — `syncForceSliders is not a function`, userTunedForces undefined, reset restores 250 not 80.
+
+- [ ] **Step 3: Implement**
+  - `main.js` settings object: add `userTunedForces: false,`.
+  - `controls.js`:
+    - In the three force-slider `wireSlider` handlers (center/repel/link), set `settings.userTunedForces = true;` before `rerunLayout()`.
+    - Add (as a top-level function declaration so it is a webview global; reuse the exact slider/label ids from the `wireSlider` call sites):
+      ```js
+      function syncForceSliders() {
+        const rows = [
+          ['slider-center-force', /* real label id */, settings.centerForce],
+          ['slider-repel-force', /* real label id */, settings.repelForce],
+          ['slider-link-force', /* real label id */, settings.linkForce],
+        ];
+        for (const [sliderId, labelId, value] of rows) {
+          const slider = document.getElementById(sliderId);
+          const label = document.getElementById(labelId);
+          if (slider) slider.value = String(value);
+          if (label) label.textContent = String(value);
+        }
+      }
+      ```
+      (Replace the `/* real label id */` placeholders with the actual ids found at the wireSlider call sites — this is a read-the-code substitution, not a design decision.)
+    - Reset handler (controls.js:66-74): replace the hardcoded `centerForce: 0.05, repelForce: 250, linkForce: 1` assignments with:
+      ```js
+      const defaults = computeForceDefaults(state.currentNodes.length);
+      settings.centerForce = defaults.centerForce;
+      settings.repelForce = defaults.repelForce;
+      settings.linkForce = defaults.linkForce;
+      settings.userTunedForces = false;
+      syncForceSliders();
+      ```
+      (keep whatever the handler already does afterwards — e.g. `rerunLayout()`.)
+  - `rendering.js` `startSimulation` full-build path, before the forces are configured:
+    ```js
+    if (!settings.userTunedForces) {
+      const defaults = computeForceDefaults(state.currentNodes.length);
+      settings.centerForce = defaults.centerForce;
+      settings.repelForce = defaults.repelForce;
+      if (typeof syncForceSliders === 'function') syncForceSliders();
+    }
+    ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/webview/main.js src/webview/controls.js src/webview/rendering.js src/test/suite/webviewControls.test.ts
+git commit -m "feat(webview): dynamic per-repo force defaults with slider sync (#27)"
+```
+
+---
+
+### Task 5: Bound the workflow view node count
+
+**Files:**
+- Modify: `src/webview/workflow.js` (add `clampWorkflowLevel`; export it in the existing guarded CJS block)
+- Modify: `src/webview/main.js` (`applyWorkflowComplexity`, lines ~174-199)
+- Test: `src/test/suite/workflowDerive.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `deriveWorkflowView(projectData, level)` (existing, workflow.js:27-101), `WORKFLOW_MAX_NODES` (Task 1).
+- Produces: `clampWorkflowLevel(projectData, level, maxNodes): number` — largest level ≤ `level` whose derived rendered-node count is ≤ `maxNodes` (level 0 is always allowed).
+
+- [ ] **Step 1: Write the failing test** — extend `src/test/suite/workflowDerive.test.ts`. Read the file's existing synthetic-graph helper first and reuse it; the test builds a graph large enough that high levels exceed the cap:
+
+```ts
+test('clampWorkflowLevel lowers the level until the derived node count fits', () => {
+  const data = makeBigWorkflowGraph(1200); // reuse/extend the file's existing graph builder
+  const clamped = workflow.clampWorkflowLevel(data, 9, 400);
+  assert.ok(clamped < 9);
+  const view = workflow.deriveWorkflowView(data, clamped);
+  assert.ok(countRenderedNodes(view) <= 400); // count via the same field buildClusteredElements consumes (clusterMembers)
+  // level 0 always allowed even if still above the cap
+  assert.strictEqual(workflow.clampWorkflowLevel(data, 0, 1), 0);
+  // small graphs are never clamped
+  const small = makeBigWorkflowGraph(50);
+  assert.strictEqual(workflow.clampWorkflowLevel(small, 9, 400), 9);
+});
+```
+
+(`countRenderedNodes` = however the existing tests count derived clusters — read workflowDerive.test.ts and use the same accessor; the rendered node count is the number of derived clusters, i.e. `view.clusterMembers.size` if clusterMembers is a Map.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — `workflow.clampWorkflowLevel is not a function`.
+
+- [ ] **Step 3: Implement** in `src/webview/workflow.js`:
+
+```js
+// Largest level <= requested whose derived view renders at most maxNodes
+// nodes (issue #52: the workflow view must stay bounded on huge repos).
+function clampWorkflowLevel(projectData, level, maxNodes) {
+  let lvl = level;
+  while (lvl > 0) {
+    const view = deriveWorkflowView(projectData, lvl);
+    if (view.clusterMembers.size <= maxNodes) { break; }
+    lvl -= 1;
+  }
+  return lvl;
+}
+```
+
+(Adjust the node-count accessor to the real shape of `deriveWorkflowView`'s return — the test from Step 1 pins it. Add `clampWorkflowLevel` to the module's existing `module.exports` guard.)
+
+In `main.js` `applyWorkflowComplexity` (lines ~174-199), clamp the level before deriving: where `deriveWorkflowView(projectData, state.workflowLevel)` is called, first do `state.workflowLevel = clampWorkflowLevel(projectData, state.workflowLevel, WORKFLOW_MAX_NODES);`.
+
+- [ ] **Step 4: Run tests to verify they pass** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/webview/workflow.js src/webview/main.js src/test/suite/workflowDerive.test.ts
+git commit -m "feat(webview): clamp workflow view detail to a bounded node count (#52)"
+```
+
+---
+
+### Task 6: Per-analyzer timing instrumentation (#50 Approach 3.1, extension side)
+
+**Files:**
+- Modify: `src/analyzerRunner.ts`
+- Test: `src/test/suite/analyzerRunner.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `log` callback (already wired to the `CoGraph` OutputChannel at graphProvider.ts:121).
+- Produces: `AnalyzerResult.durationMs: number`; `AnalyzerStatus.durationMs?: number`; `[perf]`-prefixed log lines.
+
+- [ ] **Step 1: Write the failing test** — extend `analyzerRunner.test.ts` (reuse `makeRunner`, `stubSpawnAuto`, `stubPythonResolution`, `stubFastBackoff` — and extend `makeRunner` to also capture `log` lines into an array if it doesn't already):
+
+```ts
+test('logs per-analyzer timing and totals on a successful run', async () => {
+  const logs: string[] = [];
+  const { runner, resultPromise } = makeRunnerCapturingLogs(logs); // extend makeRunner: pass log: (m) => logs.push(m)
+  stubSpawnAuto(sandbox, realSetTimeout, (call) => emitNode(call)); // all five analyzers emit a node and exit 0
+  runner.run('/w');
+  await resultPromise;
+  const perfLines = logs.filter(l => l.startsWith('[perf]'));
+  // one line per analyzer + one attempt summary
+  assert.strictEqual(perfLines.filter(l => /: ok in \d+ms$/.test(l)).length, 5);
+  assert.ok(perfLines.some(l => /analysis attempt 1: \d+ms total, \d+ nodes \/ \d+ edges/.test(l)));
+});
+```
+
+(Adapt helper names/shapes to the file's actual helpers — read lines 19-89 first. The assertion targets are the log format, which IS the deliverable.)
+
+- [ ] **Step 2: Run to verify it fails** — Expected: FAIL — no `[perf]` lines logged.
+
+- [ ] **Step 3: Implement** in `src/analyzerRunner.ts`:
+  - `AnalyzerResult` (lines 32-37): add `durationMs: number;`. `AnalyzerStatus` (lines 23-30): add `durationMs?: number;`.
+  - `spawnAnalyzerProcess` (lines 306-380): `const startedAt = Date.now();` first line; add `durationMs: Date.now() - startedAt` to **every** `resolve({ … })` site in the function (timeout, spawn-error, output-too-large, close/parse paths).
+  - `runOnce` (147-163): where statuses are built from results in the `flatMap`, carry `durationMs` through into each status entry.
+  - `runWithRetry` (98-134): capture `const attemptStart = Date.now();` at the top of each loop iteration; after `runOnce` resolves (and after the stale-token check at line 110):
+    ```ts
+    for (const s of statuses) {
+      this.log(`[perf] ${s.lang}: ${s.status} in ${s.durationMs ?? 0}ms`);
+    }
+    this.log(`[perf] analysis attempt ${attempt + 1}: ${Date.now() - attemptStart}ms total, ` +
+      `${merged.nodes.length} nodes / ${merged.edges.length} edges`);
+    ```
+  - `runSubset` (174-212): after its `Promise.all`, one line: `this.log(\`[perf] subset parse (${files.length} files): ${Date.now() - startedAt}ms\`);` with `startedAt` captured at method start.
+
+- [ ] **Step 4: Run tests to verify they pass** — Expected: PASS, including all pre-existing analyzerRunner tests (they assert on statuses and must be unaffected by the added field).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/analyzerRunner.ts src/test/suite/analyzerRunner.test.ts
+git commit -m "feat(analysis): log per-analyzer wall time and attempt totals (#50)"
+```
+
+---
+
+### Task 7: Payload metrics + webview layout-time round trip (#50 Approach 3.1)
+
+**Files:**
+- Modify: `src/graphProvider.ts` (`handleAnalysisResult` ~636-678; `onDidReceiveMessage` switch ~220-335)
+- Modify: `src/webview/state.js` (add `layoutStartedAt: null,` near `hasFitted`)
+- Modify: `src/webview/main.js` (`renderGraph` ~299-348: set `state.layoutStartedAt = Date.now();` at entry)
+- Modify: `src/webview/rendering.js` (post metrics at the settle point)
+- Test: `src/test/suite/graphProvider.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing fake-webview test pattern (graphProvider.test.ts:75-76, 349-350).
+- Produces: webview→host message `{ type: 'layout-metrics', ms: number, nodes: number }`; `[perf]` log lines in the `CoGraph` output channel.
+
+- [ ] **Step 1: Write the failing tests** — extend `graphProvider.test.ts` (mirror its existing provider + fake panel setup, and its OutputChannel stubbing if present — otherwise stub `vscode.window.createOutputChannel` in the suite's sandbox to return `{ appendLine: sinon.stub(), … }`):
+
+```ts
+test('handleAnalysisResult logs payload size metrics', () => {
+  // drive the provider's onResult callback (or handleAnalysisResult indirectly,
+  // matching how existing tests inject analysis results) with a small graph JSON
+  const stdout = JSON.stringify({ nodes: [{ id: 'a' }, { id: 'b' }], edges: [{ source: 'a', target: 'b' }] });
+  driveAnalysisResult(provider, stdout); // reuse the file's existing mechanism
+  assert.ok(appendLineStub.args.some(([line]) =>
+    /\[perf\] payload: 2 nodes \/ 1 edges, \d+(\.\d+)? (KB|MB)/.test(line)));
+});
+
+test('layout-metrics message from the webview is logged', () => {
+  const onMessage = capturedOnDidReceiveMessage(); // the callback the provider registered on the fake panel
+  onMessage({ type: 'layout-metrics', ms: 843, nodes: 1500 });
+  assert.ok(appendLineStub.args.some(([line]) =>
+    line.includes('[perf] webview layout settled in 843ms (1500 nodes)')));
+});
+```
+
+- [ ] **Step 2: Run to verify they fail** — Expected: FAIL — no `[perf]` payload/layout lines.
+
+- [ ] **Step 3: Implement**
+  - `graphProvider.ts` `handleAnalysisResult`, right after the `JSON.parse(stdout)` succeeds:
+    ```ts
+    const kb = Buffer.byteLength(stdout, 'utf8') / 1024;
+    const size = kb >= 1024 ? `${(kb / 1024).toFixed(2)} MB` : `${kb.toFixed(1)} KB`;
+    this.outputChannel.appendLine(
+      `[perf] payload: ${graph.nodes.length} nodes / ${graph.edges.length} edges, ${size}`);
+    ```
+  - `graphProvider.ts` `onDidReceiveMessage` switch: add
+    ```ts
+    case 'layout-metrics':
+      this.outputChannel.appendLine(
+        `[perf] webview layout settled in ${message.ms}ms (${message.nodes} nodes)`);
+      break;
+    ```
+  - `state.js`: add `layoutStartedAt: null,` after `hasFitted: false,`.
+  - `main.js` `renderGraph` entry: `state.layoutStartedAt = Date.now();`.
+  - `rendering.js`: add near `ticked()`:
+    ```js
+    function postLayoutMetrics() {
+      if (state.layoutStartedAt == null) { return; }
+      const ms = Date.now() - state.layoutStartedAt;
+      state.layoutStartedAt = null;
+      vscode.postMessage({ type: 'layout-metrics', ms, nodes: state.currentNodes.length });
+    }
+    ```
+    and call `postLayoutMetrics();` inside the one-shot auto-fit block from Task 2 (right after `fitToView();`). (`vscode` is the `acquireVsCodeApi()` global from main.js — same cross-file usage as popups.js.)
+
+- [ ] **Step 4: Run tests to verify they pass** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/graphProvider.ts src/webview/state.js src/webview/main.js src/webview/rendering.js src/test/suite/graphProvider.test.ts
+git commit -m "feat(perf): log payload size and webview layout settle time (#50)"
+```
+
+---
+
+### Task 8: Changelog + final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entry** — read the top of `CHANGELOG.md` and mirror its format; add under an Unreleased (or new version) heading:
+
+```markdown
+### Performance
+- Large graphs (≥800 rendered nodes) now settle and freeze instead of simulating indefinitely; dragging a node moves it directly without reheating the whole graph (#52)
+- Force defaults now scale with repository size; the Reset Layout button restores size-appropriate values (#27)
+- Workflow view detail is clamped so huge repositories never render an unbounded node count (#52)
+- The CoGraph output channel now logs per-analyzer wall time, payload size, and webview layout settle time (#50)
+
+### Fixed
+- Initial center force (0.025) now matches the slider/reset default (0.05)
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm test`
+Expected: PASS — full suite.
+Run: `$env:Path = "C:\Program Files\nodejs;$env:Path"; npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add CHANGELOG.md
+git commit -m "chore: changelog for large-repo layout performance work"
+```
+
+---
+
+## Out of Scope (report-only — do NOT implement)
+
+- **#50 Approaches 1 & 2.2-2.4** (incremental analysis cache, Web Worker simulation, canvas fallback, graph-patch deltas) — larger standalone efforts; #50 stays open.
+- **rAF-throttling tick→DOM writes (#52 item 4a)** — verified moot: d3-force ticks via d3-timer, which is already requestAnimationFrame-driven; DOM writes are already at most once per frame.
+- **#26 (dynamic dependencies), #6 (LLM cluster names)** — underspecified product features; per `.ai/system.md`, do not assume product decisions.
+- **#40 (refactor JavaScript)** — empty issue body; the tech-debt file already tracks the oversized-file split. New logic added here goes into small new modules, which is directionally aligned.
+- Persisting user-tuned force values into the save payload.

--- a/src/analyzerRunner.ts
+++ b/src/analyzerRunner.ts
@@ -34,6 +34,8 @@ export interface AnalyzerResult {
   status: AnalyzerStatus;
   lang: string;
   detail?: string;
+  /** Wall-clock time this analyzer subprocess took, from spawn to resolution. */
+  durationMs: number;
 }
 
 /** Metadata accompanying a finished analysis run, so the UI can react to failures. */
@@ -106,6 +108,7 @@ export class AnalyzerRunner {
     let statuses: AnalyzerResult[] = [];
 
     for (let attempt = 0; attempt <= MAX_ANALYSIS_RETRIES; attempt++) {
+      const attemptStart = Date.now();
       const result = await this.runOnce(workspaceRoot, pythonBin);
       if (token !== this.runToken) { return; } // superseded by killAll() or a newer run
       merged = result.merged;
@@ -117,6 +120,13 @@ export class AnalyzerRunner {
           this.log(`Analyzer [${s.lang}] ${s.status}${s.detail ? `: ${s.detail}` : ''}`);
         }
       }
+
+      // Timing breakdown — turns "it's slow" into per-analyzer numbers (#50).
+      for (const s of statuses) {
+        this.log(`[perf] ${s.lang}: ${s.status} in ${s.durationMs ?? 0}ms`);
+      }
+      this.log(`[perf] analysis attempt ${attempt + 1}: ${Date.now() - attemptStart}ms total, ` +
+        `${merged.nodes.length} nodes / ${merged.edges.length} edges`);
 
       if (merged.nodes.length > 0) { break; } // success — even a partial graph beats retrying
 
@@ -172,6 +182,7 @@ export class AnalyzerRunner {
    * un-parsed files may be incomplete until the full background pass reconciles.
    */
   async runSubset(workspaceRoot: string, files: string[]): Promise<GraphData> {
+    const startedAt = Date.now();
     const empty: GraphData = { nodes: [], edges: [], files: [] };
     if (files.length === 0) { return empty; }
     const pythonBin = this.resolvePythonBin();
@@ -201,6 +212,7 @@ export class AnalyzerRunner {
           this.log(`Subset analyzer [${s.lang}] ${s.status}${s.detail ? `: ${s.detail}` : ''}`);
         }
       }
+      this.log(`[perf] subset parse (${files.length} files): ${Date.now() - startedAt}ms`);
       return {
         nodes: statuses.flatMap(r => r.graph.nodes),
         edges: statuses.flatMap(r => r.graph.edges),
@@ -304,8 +316,10 @@ export class AnalyzerRunner {
   }
 
   private spawnAnalyzerProcess(bin: string, args: string[], lang: string): Promise<AnalyzerResult> {
+    const startedAt = Date.now();
     const empty: GraphData = { nodes: [], edges: [], files: [] };
-    const fail = (status: AnalyzerStatus, detail?: string): AnalyzerResult => ({ graph: empty, status, lang, detail });
+    const fail = (status: AnalyzerStatus, detail?: string): AnalyzerResult =>
+      ({ graph: empty, status, lang, detail, durationMs: Date.now() - startedAt });
     return new Promise((resolve) => {
       let proc: cp.ChildProcess;
       try {
@@ -371,7 +385,7 @@ export class AnalyzerRunner {
         }
         try {
           const graph = JSON.parse(stdout) as GraphData;
-          resolve({ graph, status: graph.nodes.length > 0 ? 'ok' : 'empty', lang });
+          resolve({ graph, status: graph.nodes.length > 0 ? 'ok' : 'empty', lang, durationMs: Date.now() - startedAt });
         } catch {
           resolve(fail('parse-error', stderr ? stderr.slice(0, 300).trim() : 'invalid JSON'));
         }

--- a/src/graphProvider.ts
+++ b/src/graphProvider.ts
@@ -327,6 +327,9 @@ export class GraphProvider {
       } else if (message.type === 'cancel-analysis') {
         this.analyzerRunner.killAll();
         this.panel?.webview.postMessage({ type: 'analysis-state', backgroundParsing: false, cancelled: true });
+      } else if (message.type === 'layout-metrics') {
+        this.outputChannel.appendLine(
+          `[perf] webview layout settled in ${message.ms}ms (${message.nodes} nodes)`);
       } else if (message.type === 'open-chat') {
         // Focuses the Cograph activity-bar view. The current graph context is
         // already up-to-date — setCurrentGraph is invoked from loadGraph and
@@ -643,6 +646,11 @@ export class GraphProvider {
       this.showError('CoGraph: Failed to parse graph data.');
       return;
     }
+
+    const kb = Buffer.byteLength(stdout, 'utf8') / 1024;
+    const size = kb >= 1024 ? `${(kb / 1024).toFixed(2)} MB` : `${kb.toFixed(1)} KB`;
+    this.outputChannel.appendLine(
+      `[perf] payload: ${graph.nodes.length} nodes / ${graph.edges.length} edges, ${size}`);
 
     // A 0-node result is only a dead-end when NO skeleton is shown. With the
     // file-cluster skeleton up, the structure stays and analysis just adds nothing.

--- a/src/test/suite/analyzerRunner.test.ts
+++ b/src/test/suite/analyzerRunner.test.ts
@@ -126,6 +126,29 @@ suite('AnalyzerRunner', () => {
     assert.strictEqual(meta.statuses.find(s => s.lang === 'typescript')!.status, 'empty');
   });
 
+  test('logs per-analyzer timing and attempt totals on a successful run', async function () {
+    this.timeout(5000);
+    stubPythonResolution(sandbox);
+    // Every analyzer emits a node and exits 0 → clean, single-attempt run.
+    stubSpawnAuto(sandbox, realSetTimeout, (_idx, proc) => emitNode(proc));
+    const { runner, log, result } = makeRunner(sandbox);
+
+    runner.run('/ws', { allowRetry: true });
+    await result;
+
+    const perfLines = log.getCalls().map(c => String(c.args[0])).filter(l => l.startsWith('[perf]'));
+    // One "<lang>: ok in <n>ms" line per analyzer …
+    assert.strictEqual(
+      perfLines.filter(l => /: ok in \d+ms$/.test(l)).length, 5,
+      'one timing line per analyzer',
+    );
+    // … plus one attempt summary carrying elapsed time and graph totals.
+    assert.ok(
+      perfLines.some(l => /analysis attempt 1: \d+ms total, \d+ nodes \/ \d+ edges/.test(l)),
+      'attempt summary line with totals',
+    );
+  });
+
   test('analyzer exit-nonzero is surfaced (logged + status), never swallowed', async function () {
     this.timeout(5000);
     stubPythonResolution(sandbox);

--- a/src/test/suite/graphProvider.test.ts
+++ b/src/test/suite/graphProvider.test.ts
@@ -333,6 +333,55 @@ suite('GraphProvider', () => {
     });
   });
 
+  // ── [perf] instrumentation ─────────────────────────────────────────────────
+
+  suite('perf metrics logging', () => {
+    test('handleAnalysisResult logs payload size metrics', () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([{ uri: { fsPath: '/ws' } }]);
+      const fakePanel = makeFakePanel();
+      sandbox.stub(vscode.window, 'createWebviewPanel').returns(fakePanel as any);
+      sandbox.stub(rawCp, 'execFileSync').returns(Buffer.from('Python 3.11.0'));
+      // Procs never complete, so the live run never overwrites the panel.
+      stubSpawnAuto(sandbox, setTimeout, () => { /* never emits */ });
+      const appendLine = sinon.stub();
+      sandbox.stub(vscode.window, 'createOutputChannel').returns({ appendLine } as any);
+
+      const provider = new GraphProvider(makeFakeContext());
+      provider.show();
+
+      const stdout = JSON.stringify({
+        nodes: [{ id: 'a' }, { id: 'b' }],
+        edges: [{ source: 'a', target: 'b' }],
+      });
+      (provider as any).handleAnalysisResult(stdout, '/ws');
+
+      assert.ok(
+        appendLine.args.some(([line]) =>
+          /\[perf\] payload: 2 nodes \/ 1 edges, \d+(\.\d+)? (KB|MB)/.test(line)),
+        `expected a [perf] payload line, got: ${JSON.stringify(appendLine.args)}`,
+      );
+    });
+
+    test('layout-metrics message from the webview is logged', () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([{ uri: { fsPath: '/ws' } }]);
+      const appendLine = sinon.stub();
+      sandbox.stub(vscode.window, 'createOutputChannel').returns({ appendLine } as any);
+      const { msgCallbacks } = setupPanelWithCapturedMessages(sandbox);
+
+      const provider = new GraphProvider(makeFakeContext());
+      provider.show();
+
+      assert.ok(msgCallbacks.length >= 1, 'message callback should be registered');
+      msgCallbacks[0]({ type: 'layout-metrics', ms: 843, nodes: 1500 });
+
+      assert.ok(
+        appendLine.args.some(([line]) =>
+          line.includes('[perf] webview layout settled in 843ms (1500 nodes)')),
+        `expected a [perf] layout line, got: ${JSON.stringify(appendLine.args)}`,
+      );
+    });
+  });
+
   // ── retry-analysis message ─────────────────────────────────────────────────
 
   suite('retry-analysis message', () => {

--- a/src/test/suite/layoutTuning.test.ts
+++ b/src/test/suite/layoutTuning.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert';
+
+// Pure module, guarded CJS export (same pattern as aggregate.js).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tuning = require('../../../src/webview/layoutTuning.js');
+
+suite('layoutTuning', () => {
+  suite('computeForceDefaults', () => {
+    test('small graphs keep the current defaults', () => {
+      for (const n of [0, 10, 250, 499]) {
+        assert.deepStrictEqual(tuning.computeForceDefaults(n),
+          { centerForce: 0.05, repelForce: 250, linkForce: 1 });
+      }
+    });
+    test('very large graphs get compact params (strong center, weak repel)', () => {
+      const d = tuning.computeForceDefaults(3000);
+      assert.strictEqual(d.centerForce, 0.15);
+      assert.strictEqual(d.repelForce, 80);
+      assert.strictEqual(d.linkForce, 1);
+      // clamped beyond the scale window
+      assert.deepStrictEqual(tuning.computeForceDefaults(50000), d);
+    });
+    test('scales monotonically between 500 and 3000 nodes', () => {
+      let prevCenter = 0;
+      let prevRepel = Infinity;
+      for (const n of [500, 1000, 1750, 2500, 3000]) {
+        const d = tuning.computeForceDefaults(n);
+        assert.ok(d.centerForce >= prevCenter, `centerForce non-decreasing at ${n}`);
+        assert.ok(d.repelForce <= prevRepel, `repelForce non-increasing at ${n}`);
+        prevCenter = d.centerForce;
+        prevRepel = d.repelForce;
+      }
+    });
+  });
+
+  suite('size thresholds', () => {
+    test('large-graph boundary at 800 nodes', () => {
+      assert.strictEqual(tuning.isLargeGraph(799), false);
+      assert.strictEqual(tuning.isLargeGraph(800), true);
+      assert.strictEqual(tuning.LARGE_GRAPH_NODE_THRESHOLD, 800);
+    });
+    test('collide and drag-reheat stay on for small graphs, off for large', () => {
+      assert.strictEqual(tuning.useCollide(799), true);
+      assert.strictEqual(tuning.useCollide(800), false);
+      assert.strictEqual(tuning.dragShouldReheat(799), true);
+      assert.strictEqual(tuning.dragShouldReheat(800), false);
+    });
+    test('alphaDecay unchanged for small graphs, faster for large', () => {
+      assert.strictEqual(tuning.alphaDecayFor(799), 0.02);
+      assert.strictEqual(tuning.alphaDecayFor(800), 0.05);
+    });
+  });
+
+  suite('shouldFreeze', () => {
+    test('never freezes small graphs', () => {
+      assert.strictEqual(tuning.shouldFreeze(0.001, 799), false);
+    });
+    test('freezes large graphs only once alpha settles below 0.05', () => {
+      assert.strictEqual(tuning.shouldFreeze(0.06, 800), false);
+      assert.strictEqual(tuning.shouldFreeze(0.049, 800), true);
+    });
+  });
+});

--- a/src/test/suite/webviewControls.test.ts
+++ b/src/test/suite/webviewControls.test.ts
@@ -25,6 +25,7 @@ function makeDOM() {
     <input id="slider-center-force" type="range" value="1" /><span id="val-center-force">1</span>
     <input id="slider-repel-force" type="range" value="50" /><span id="val-repel-force">50</span>
     <input id="slider-link-force" type="range" value="1" /><span id="val-link-force">1</span>
+    <button id="btn-reset-layout"></button>
     <div id="toggle-git-legend"><span class="tl-chevron">▾</span></div>
     <div id="git-legend-body"></div>
     <div id="toggle-folder-filters"><span class="tl-chevron">▾</span></div>
@@ -110,14 +111,21 @@ let rerunLayoutCallCount = 0;
 (global as any).updateFuncHighlight = () => {};
 (global as any).updateSaveBtn = () => {};
 (global as any).highlightCode = () => '';
+// computeForceDefaults is a shared script global in the real webview; the reset
+// handler + startSimulation call it. Install the pure module here (Task 1).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+(global as any).computeForceDefaults = require('../../../src/webview/layoutTuning.js').computeForceDefaults;
 
 // Load controls.js (attaches all event listeners to existing DOM elements)
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('../../../src/webview/controls.js');
 
-// Also get applyResizeDelta / applySavedViewSettings for direct testing
+// Also get applyResizeDelta / applySavedViewSettings for direct testing.
+// syncForceSliders is a shared script global in the real webview; expose it as
+// one here so tests (and the reset handler) can reach it the same way.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { applyResizeDelta, applySavedViewSettings } = require('../../../src/webview/controls.js');
+const { applyResizeDelta, applySavedViewSettings, syncForceSliders } = require('../../../src/webview/controls.js');
+(global as any).syncForceSliders = syncForceSliders;
 
 // Load popups.js factory for textarea handler tests
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -729,5 +737,39 @@ suite('applySavedViewSettings()', () => {
     assert.strictEqual(st().clusterGroupBy, before.clusterGroupBy);
     assert.strictEqual(st().gitMode, before.gitMode);
     assert.strictEqual(st().folderMode, before.folderMode);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: dynamic force defaults (#27)
+// ---------------------------------------------------------------------------
+
+suite('dynamic force defaults (#27)', () => {
+  test('force slider input marks settings.userTunedForces', () => {
+    (global as any).settings.userTunedForces = false;
+    const slider = dom.window.document.getElementById('slider-repel-force') as any;
+    slider.value = '300';
+    dispatch(slider, 'input');
+    assert.strictEqual((global as any).settings.userTunedForces, true);
+  });
+
+  test('syncForceSliders pushes settings values into sliders and labels', () => {
+    (global as any).settings.centerForce = 0.15;
+    (global as any).settings.repelForce = 80;
+    (global as any).settings.linkForce = 1;
+    (global as any).syncForceSliders();
+    const slider = dom.window.document.getElementById('slider-repel-force') as any;
+    assert.strictEqual(slider.value, '80');
+    assert.strictEqual(dom.window.document.getElementById('val-repel-force')!.textContent, '80');
+  });
+
+  test('reset restores size-based defaults and clears userTunedForces', () => {
+    (global as any).state.currentNodes = new Array(3000).fill(0).map((_, i) => ({ id: String(i) }));
+    (global as any).settings.userTunedForces = true;
+    (global as any).settings.repelForce = 999;
+    const btn = dom.window.document.getElementById('btn-reset-layout') as any;
+    dispatch(btn, 'click');
+    assert.strictEqual((global as any).settings.repelForce, 80);
+    assert.strictEqual((global as any).settings.userTunedForces, false);
   });
 });

--- a/src/test/suite/webviewControls.test.ts
+++ b/src/test/suite/webviewControls.test.ts
@@ -745,6 +745,28 @@ suite('applySavedViewSettings()', () => {
 // ---------------------------------------------------------------------------
 
 suite('dynamic force defaults (#27)', () => {
+  let savedUserTunedForces: any;
+  let savedRepelForce: any;
+  let savedCenterForce: any;
+  let savedLinkForce: any;
+  let savedCurrentNodes: any;
+
+  setup(() => {
+    savedUserTunedForces = (global as any).settings.userTunedForces;
+    savedRepelForce = (global as any).settings.repelForce;
+    savedCenterForce = (global as any).settings.centerForce;
+    savedLinkForce = (global as any).settings.linkForce;
+    savedCurrentNodes = (global as any).state.currentNodes;
+  });
+
+  teardown(() => {
+    (global as any).settings.userTunedForces = savedUserTunedForces;
+    (global as any).settings.repelForce = savedRepelForce;
+    (global as any).settings.centerForce = savedCenterForce;
+    (global as any).settings.linkForce = savedLinkForce;
+    (global as any).state.currentNodes = savedCurrentNodes;
+  });
+
   test('force slider input marks settings.userTunedForces', () => {
     (global as any).settings.userTunedForces = false;
     const slider = dom.window.document.getElementById('slider-repel-force') as any;

--- a/src/test/suite/workflowDerive.test.ts
+++ b/src/test/suite/workflowDerive.test.ts
@@ -5,12 +5,41 @@ import * as assert from 'assert';
 // clustering.test.ts — we reach the source file: out/test/suite → project root
 // → src/webview/workflow.js.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { deriveWorkflowView, computeColumnX, WORKFLOW_LEVELS } = require('../../../src/webview/workflow.js');
+const { deriveWorkflowView, computeColumnX, clampWorkflowLevel, WORKFLOW_LEVELS } = require('../../../src/webview/workflow.js');
 
 interface WfNode { id: string; name: string; file: string | null; line: number; isLibrary?: boolean; workflow?: Record<string, unknown>; }
 
 function n(id: string, file: string | null, stage: number, tier: string, rank: number, cluster: string): WfNode {
   return { id, name: id, file, line: 1, workflow: { rank, stage, tier, cluster, clusterName: cluster.toUpperCase() } };
+}
+
+// A large synthetic workflow graph with `count` internal nodes spread across a
+// fixed, small number of (stage, tier) cells and topic clusters — so level 9
+// renders `count` individual nodes (blows past any small cap) while level 0
+// collapses to a handful of cells. Reuses the `n()` node builder above.
+function makeBigWorkflowGraph(count: number) {
+  const tiers = ['backend', 'shared', 'frontend'];
+  const numStages = 6;
+  const numClusters = 8;
+  const nodes: WfNode[] = [];
+  for (let i = 0; i < count; i++) {
+    const stage = i % numStages;
+    const tier = tiers[i % tiers.length];
+    const cluster = 'c' + (i % numClusters);
+    nodes.push(n('n' + i, 'f' + stage + '.ts', stage, tier, i, cluster));
+  }
+  nodes.push({ id: 'lib::x', name: 'x', file: null, line: 0, isLibrary: true });
+  return {
+    nodes,
+    edges: [{ source: '::MAIN::0', target: 'n0' }],
+    workflow: { stageCount: numStages, dividerStage: numStages - 1 },
+  };
+}
+
+// The rendered-node count is the number of derived clusters — the same field
+// buildClusteredElements consumes and that the deriveWorkflowView tests assert on.
+function countRenderedNodes(view: { clusterMembers: Map<string, unknown> }): number {
+  return view.clusterMembers.size;
 }
 
 // 6 internal nodes across 3 stages / 2 tiers + a library node + a ::MAIN::0 entry edge.
@@ -126,5 +155,25 @@ suite('workflow.js — computeColumnX', () => {
   test('clamps out-of-range stage', () => {
     assert.strictEqual(computeColumnX(99, 3, W, M), 900);
     assert.strictEqual(computeColumnX(-1, 3, W, M), 100);
+  });
+});
+
+suite('workflow.js — clampWorkflowLevel', () => {
+  test('lowers the level until the derived node count fits', () => {
+    const data = makeBigWorkflowGraph(1200);
+    const clamped = clampWorkflowLevel(data, 9, 400);
+    assert.ok(clamped < 9, `expected clamp below 9, got ${clamped}`);
+    const view = deriveWorkflowView(data, clamped);
+    assert.ok(countRenderedNodes(view) <= 400, `clamped level ${clamped} renders ${countRenderedNodes(view)} nodes`);
+  });
+
+  test('level 0 is always allowed even when still above the cap', () => {
+    const data = makeBigWorkflowGraph(1200);
+    assert.strictEqual(clampWorkflowLevel(data, 0, 1), 0);
+  });
+
+  test('small graphs are never clamped', () => {
+    const small = makeBigWorkflowGraph(50);
+    assert.strictEqual(clampWorkflowLevel(small, 9, 400), 9);
   });
 });

--- a/src/webview/class.js
+++ b/src/webview/class.js
@@ -154,21 +154,24 @@ function createClassDrag() {
     .on('start', function(event, d) {
       d._dragStart = { x: event.x, y: event.y };
       d._nodeStarts = d.nodes.map(n => ({ n, x: n.x ?? 0, y: n.y ?? 0 }));
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation)
         state.simulation.alphaTarget(0.3).restart();
       d.nodes.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function(event, d) {
+      // Frozen sim (static or large graph): apply positions directly + repaint.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       const dx = event.x - d._dragStart.x, dy = event.y - d._dragStart.y;
       d._nodeStarts.forEach(({ n, x, y }) => {
         n.fx = x + dx; n.fy = y + dy;
-        if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+        if (applyDirect) { n.x = n.fx; n.y = n.fy; }
       });
-      if (state.layoutMode === 'static') ticked();
+      if (applyDirect) ticked();
     })
     .on('end', function(event, d) {
       delete d._dragStart; delete d._nodeStarts;
-      if (state.layoutMode === 'dynamic') {
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) state.simulation.alphaTarget(0);
         d.nodes.forEach(n => { n.fx = null; n.fy = null; });
       }
@@ -187,24 +190,27 @@ function createClassResizeDrag() {
       d._resizeCenter = { x: cx, y: cy };
       d._resizeStartDist = Math.hypot(event.x - cx, event.y - cy) || 1;
       d._nodeStarts = d.nodes.map(n => ({ n, ox: (n.x ?? 0) - cx, oy: (n.y ?? 0) - cy }));
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation)
         state.simulation.alphaTarget(0.3).restart();
       d.nodes.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function(event, d) {
       if (!d._nodeStarts) return;
+      // Frozen sim (static or large graph): apply positions directly + repaint.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       const { x: cx, y: cy } = d._resizeCenter;
       const scale = (Math.hypot(event.x - cx, event.y - cy) || 1) / d._resizeStartDist;
       d._nodeStarts.forEach(({ n, ox, oy }) => {
         n.fx = cx + ox * scale; n.fy = cy + oy * scale;
-        if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+        if (applyDirect) { n.x = n.fx; n.y = n.fy; }
       });
-      if (state.layoutMode === 'static') ticked();
+      if (applyDirect) ticked();
     })
     .on('end', function(event, d) {
       const hadResize = !!d._nodeStarts;
       delete d._nodeStarts; delete d._resizeCenter; delete d._resizeStartDist;
-      if (hadResize && state.layoutMode === 'dynamic') {
+      if (hadResize && state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) state.simulation.alphaTarget(0);
         d.nodes.forEach(n => { n.fx = null; n.fy = null; });
       }

--- a/src/webview/controls.js
+++ b/src/webview/controls.js
@@ -67,10 +67,7 @@ document.getElementById('btn-reset-layout')?.addEventListener('click', () => {
     textFadeThreshold: 0.5,
     nodeSize: 2.5,
     textSize: 1.5,
-    linkThickness: 4,
-    centerForce: 0.05,
-    repelForce: 250,
-    linkForce: 1
+    linkThickness: 4
   };
 
   Object.assign(settings, defaults);
@@ -79,16 +76,23 @@ document.getElementById('btn-reset-layout')?.addEventListener('click', () => {
     'slider-text-fade': { valId: 'val-text-fade', value: defaults.textFadeThreshold },
     'slider-node-size': { valId: 'val-node-size', value: defaults.nodeSize },
     'slider-text-size': { valId: 'val-text-size', value: defaults.textSize },
-    'slider-link-thickness': { valId: 'val-link-thickness', value: defaults.linkThickness },
-    'slider-center-force': { valId: 'val-center-force', value: defaults.centerForce },
-    'slider-repel-force': { valId: 'val-repel-force', value: defaults.repelForce },
-    'slider-link-force': { valId: 'val-link-force', value: defaults.linkForce }
+    'slider-link-thickness': { valId: 'val-link-thickness', value: defaults.linkThickness }
   })) {
     const slider = document.getElementById(key);
     const valEl = document.getElementById(val.valId);
     if (slider) slider.value = val.value;
     if (valEl) valEl.textContent = val.value;
   }
+
+  // Forces reset to the size-aware defaults (#27), not fixed 0.05/250/1 — a
+  // small repo (≤500 nodes) still lands on today's values. Clearing the
+  // user-tuned flag re-arms dynamic defaults; syncForceSliders mirrors them.
+  const forceDefaults = computeForceDefaults(state.currentNodes.length);
+  settings.centerForce = forceDefaults.centerForce;
+  settings.repelForce = forceDefaults.repelForce;
+  settings.linkForce = forceDefaults.linkForce;
+  settings.userTunedForces = false;
+  syncForceSliders();
 
   applyDisplaySettings();
   rerunLayout();
@@ -111,13 +115,36 @@ function wireSlider(id, valId, settingsKey, onInput) {
   });
 }
 
+// Push the three main force values from `settings` back into their sliders +
+// value labels. Called after dynamic size-based defaults (#27) mutate settings
+// (Reset, and startSimulation) so the controls reflect the applied values.
+function syncForceSliders() {
+  const rows = [
+    ['slider-center-force', 'val-center-force', settings.centerForce],
+    ['slider-repel-force', 'val-repel-force', settings.repelForce],
+    ['slider-link-force', 'val-link-force', settings.linkForce],
+  ];
+  for (const [sliderId, labelId, value] of rows) {
+    const slider = document.getElementById(sliderId);
+    const label = document.getElementById(labelId);
+    if (slider) slider.value = String(value);
+    if (label) label.textContent = String(value);
+  }
+}
+
 wireSlider('slider-text-fade', 'val-text-fade', 'textFadeThreshold', applyDisplaySettings);
 wireSlider('slider-node-size', 'val-node-size', 'nodeSize', applyDisplaySettings);
 wireSlider('slider-text-size', 'val-text-size', 'textSize', applyDisplaySettings);
 wireSlider('slider-link-thickness', 'val-link-thickness', 'linkThickness', applyDisplaySettings);
-wireSlider('slider-center-force', 'val-center-force', 'centerForce', rerunLayout);
-wireSlider('slider-repel-force', 'val-repel-force', 'repelForce', rerunLayout);
-wireSlider('slider-link-force', 'val-link-force', 'linkForce', rerunLayout);
+// Hand-tuning any of the three main forces opts this repo out of the dynamic
+// size-based defaults (#27) until the next Reset.
+function markForcesTunedAndRerun() {
+  settings.userTunedForces = true;
+  rerunLayout();
+}
+wireSlider('slider-center-force', 'val-center-force', 'centerForce', markForcesTunedAndRerun);
+wireSlider('slider-repel-force', 'val-repel-force', 'repelForce', markForcesTunedAndRerun);
+wireSlider('slider-link-force', 'val-link-force', 'linkForce', markForcesTunedAndRerun);
 wireSlider('slider-file-cluster', 'val-file-cluster', 'fileClusterForce', rerunLayout);
 wireSlider('slider-folder-repel', 'val-folder-repel', 'folderRepelForce', rerunLayout);
 wireSlider('slider-file-repel', 'val-file-repel', 'fileRepelForce', rerunLayout);
@@ -387,7 +414,7 @@ document.addEventListener('keydown', (e) => {
 });
 
 if (typeof module !== 'undefined') {
-  module.exports = { applyResizeDelta, applySavedViewSettings };
+  module.exports = { applyResizeDelta, applySavedViewSettings, syncForceSliders };
 }
 
 // ── Resize math helper ────────────────────────────────────────────────────────

--- a/src/webview/folder.js
+++ b/src/webview/folder.js
@@ -618,16 +618,20 @@ function createFileDrag() {
       } else {
         d._nodeStarts = d.nodes.map(n => ({ n, x: n.x ?? 0, y: n.y ?? 0 }));
       }
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation)
         state.simulation.alphaTarget(0.3).restart();
       d.nodes.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function(event, d) {
+      // static, or a large graph frozen after settling (issue #52): the sim
+      // won't tick on its own, so apply positions directly and repaint once.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       if (d.nodes.length === 0) {
         if (!d._emptyStart) return;
         d._cx = d._emptyStart.cx + (event.x - d._emptyStart.ex);
         d._cy = d._emptyStart.cy + (event.y - d._emptyStart.ey);
-        if (state.layoutMode === 'static') ticked();
+        if (applyDirect) ticked();
         return;
       }
       if (d._dragMode === 'resize') {
@@ -635,22 +639,22 @@ function createFileDrag() {
         const scale = (Math.hypot(event.x - cx, event.y - cy) || 1) / d._resizeStartDist;
         d._nodeStarts.forEach(({ n, ox, oy }) => {
           n.fx = cx + ox * scale; n.fy = cy + oy * scale;
-          if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+          if (applyDirect) { n.x = n.fx; n.y = n.fy; }
         });
       } else {
         const dx = event.x - d._dragStart.x, dy = event.y - d._dragStart.y;
         d._nodeStarts.forEach(({ n, x, y }) => {
           n.fx = x + dx; n.fy = y + dy;
-          if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+          if (applyDirect) { n.x = n.fx; n.y = n.fy; }
         });
       }
-      if (state.layoutMode === 'static') ticked();
+      if (applyDirect) ticked();
     })
     .on('end', function(event, d) {
       if (d.nodes.length === 0) { delete d._emptyStart; return; }
       delete d._dragStart; delete d._nodeStarts; delete d._dragMode;
       delete d._resizeCenter; delete d._resizeStartDist;
-      if (state.layoutMode === 'dynamic') {
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) state.simulation.alphaTarget(0);
         d.nodes.forEach(n => { n.fx = null; n.fy = null; });
       }
@@ -663,21 +667,24 @@ function createFolderDrag() {
     .on('start', function(event, d) {
       d._dragStart = { x: event.x, y: event.y };
       d._nodeStarts = d.allNodes.map(n => ({ n, x: n.x ?? 0, y: n.y ?? 0 }));
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation)
         state.simulation.alphaTarget(0.3).restart();
       d.allNodes.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function(event, d) {
+      // Frozen sim (static or large graph): apply positions directly + repaint.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       const dx = event.x - d._dragStart.x, dy = event.y - d._dragStart.y;
       d._nodeStarts.forEach(({ n, x, y }) => {
         n.fx = x + dx; n.fy = y + dy;
-        if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+        if (applyDirect) { n.x = n.fx; n.y = n.fy; }
       });
-      if (state.layoutMode === 'static') ticked();
+      if (applyDirect) ticked();
     })
     .on('end', function(event, d) {
       delete d._dragStart; delete d._nodeStarts;
-      if (state.layoutMode === 'dynamic') {
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) state.simulation.alphaTarget(0);
         d.allNodes.forEach(n => { n.fx = null; n.fy = null; });
       }
@@ -701,24 +708,27 @@ function createFolderResizeDrag() {
       d._resizeCenter = { x: cx, y: cy };
       d._resizeStartDist = Math.hypot(event.x - cx, event.y - cy) || 1;
       d._nodeStarts = d.allNodes.map(n => ({ n, ox: (n.x ?? 0) - cx, oy: (n.y ?? 0) - cy }));
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation)
         state.simulation.alphaTarget(0.3).restart();
       d.allNodes.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function(event, d) {
       if (!d._nodeStarts) return;
+      // Frozen sim (static or large graph): apply positions directly + repaint.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       const { x: cx, y: cy } = d._resizeCenter;
       const scale = (Math.hypot(event.x - cx, event.y - cy) || 1) / d._resizeStartDist;
       d._nodeStarts.forEach(({ n, ox, oy }) => {
         n.fx = cx + ox * scale; n.fy = cy + oy * scale;
-        if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+        if (applyDirect) { n.x = n.fx; n.y = n.fy; }
       });
-      if (state.layoutMode === 'static') ticked();
+      if (applyDirect) ticked();
     })
     .on('end', function(event, d) {
       const hadResize = !!d._nodeStarts;
       delete d._nodeStarts; delete d._resizeCenter; delete d._resizeStartDist;
-      if (hadResize && state.layoutMode === 'dynamic') {
+      if (hadResize && state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) state.simulation.alphaTarget(0);
         d.allNodes.forEach(n => { n.fx = null; n.fy = null; });
       }
@@ -855,22 +865,25 @@ function createDrilldownBoxDrag() {
     .on('start', function (event, d) {
       d._dragStart = { x: event.x, y: event.y };
       d._nodeStarts = d.members.map(n => ({ n, x: n.x ?? 0, y: n.y ?? 0 }));
-      if (state.layoutMode === 'dynamic' && !event.active && state.simulation) {
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+          && !event.active && state.simulation) {
         state.simulation.alphaTarget(0.3).restart();
       }
       d.members.forEach(n => { n.fx = n.x; n.fy = n.y; });
     })
     .on('drag', function (event, d) {
+      // Frozen sim (static or large graph): apply positions directly + repaint.
+      const applyDirect = state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length);
       const dx = event.x - d._dragStart.x, dy = event.y - d._dragStart.y;
       d._nodeStarts.forEach(({ n, x, y }) => {
         n.fx = x + dx; n.fy = y + dy;
-        if (state.layoutMode === 'static') { n.x = n.fx; n.y = n.fy; }
+        if (applyDirect) { n.x = n.fx; n.y = n.fy; }
       });
-      if (state.layoutMode === 'static') { ticked(); }
+      if (applyDirect) { ticked(); }
     })
     .on('end', function (event, d) {
       delete d._dragStart; delete d._nodeStarts;
-      if (state.layoutMode === 'dynamic') {
+      if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
         if (!event.active && state.simulation) { state.simulation.alphaTarget(0); }
         d.members.forEach(n => { n.fx = null; n.fy = null; });
       }

--- a/src/webview/layoutTuning.js
+++ b/src/webview/layoutTuning.js
@@ -1,0 +1,62 @@
+// Pure size-based tuning decisions for the force layout (issues #52, #27).
+// No DOM, no d3 — keep it require()-able from Node tests (see aggregate.js).
+
+// Above this rendered-node count the simulation gets the "large graph"
+// treatment: faster settle, no collide force, no global reheat on drag.
+const LARGE_GRAPH_NODE_THRESHOLD = 800;
+// computeForceDefaults interpolates between these two sizes.
+const FORCE_SCALE_MIN_NODES = 500;
+const FORCE_SCALE_MAX_NODES = 3000;
+// Large graphs stop simulating below this alpha (d3 default alphaMin is
+// 0.001 — stopping at 0.05 saves the long low-energy tail of ticks).
+const SETTLE_ALPHA_LARGE = 0.05;
+const ALPHA_DECAY_SMALL = 0.02; // current value in startSimulation
+const ALPHA_DECAY_LARGE = 0.05;
+// Cap on rendered workflow-view nodes (issue #52 item 2).
+const WORKFLOW_MAX_NODES = 400;
+
+function isLargeGraph(nodeCount) {
+  return nodeCount >= LARGE_GRAPH_NODE_THRESHOLD;
+}
+
+// Dynamic per-repo force defaults (issue #27): small graphs keep today's
+// values; large graphs get stronger centering and weaker repel so the
+// layout stays compact instead of exploding.
+function computeForceDefaults(nodeCount) {
+  const span = FORCE_SCALE_MAX_NODES - FORCE_SCALE_MIN_NODES;
+  const t = Math.max(0, Math.min(1, (nodeCount - FORCE_SCALE_MIN_NODES) / span));
+  return {
+    centerForce: Math.round((0.05 + t * 0.10) * 1000) / 1000,
+    repelForce: Math.round(250 - t * 170),
+    linkForce: 1,
+  };
+}
+
+function alphaDecayFor(nodeCount) {
+  return isLargeGraph(nodeCount) ? ALPHA_DECAY_LARGE : ALPHA_DECAY_SMALL;
+}
+
+function useCollide(nodeCount) {
+  return !isLargeGraph(nodeCount);
+}
+
+function dragShouldReheat(nodeCount) {
+  return !isLargeGraph(nodeCount);
+}
+
+function shouldFreeze(alpha, nodeCount) {
+  return isLargeGraph(nodeCount) && alpha < SETTLE_ALPHA_LARGE;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    LARGE_GRAPH_NODE_THRESHOLD,
+    WORKFLOW_MAX_NODES,
+    isLargeGraph,
+    computeForceDefaults,
+    alphaDecayFor,
+    useCollide,
+    dragShouldReheat,
+    shouldFreeze,
+  };
+}

--- a/src/webview/main.js
+++ b/src/webview/main.js
@@ -38,7 +38,7 @@ const settings = {
   nodeSize: 2.5,
   textSize: 1.5,
   linkThickness: 4,
-  centerForce: 0.025,
+  centerForce: 0.05,
   repelForce: 250,
   linkForce: 1,
   fileClusterForce: 0.2,

--- a/src/webview/main.js
+++ b/src/webview/main.js
@@ -185,6 +185,10 @@ function applyWorkflowComplexity() {
     degreeMap.set(e.source, (degreeMap.get(e.source) ?? 0) + 1);
     degreeMap.set(e.target, (degreeMap.get(e.target) ?? 0) + 1);
   });
+  // Bound the rendered node count on huge repos (issue #52 item 2): the slider
+  // may request more detail than the view can show, so lower the effective level
+  // until it fits WORKFLOW_MAX_NODES (level 0 is always allowed).
+  state.workflowLevel = clampWorkflowLevel(projectData, state.workflowLevel, WORKFLOW_MAX_NODES);
   const wv = deriveWorkflowView(projectData, state.workflowLevel);
   state.workflowStageCount = wv.stageCount;
   state.workflowDividerStage = wv.dividerStage;

--- a/src/webview/main.js
+++ b/src/webview/main.js
@@ -41,6 +41,7 @@ const settings = {
   centerForce: 0.05,
   repelForce: 250,
   linkForce: 1,
+  userTunedForces: false,
   fileClusterForce: 0.2,
   folderRepelForce: 0.25,
   fileRepelForce: 0.25,

--- a/src/webview/main.js
+++ b/src/webview/main.js
@@ -302,6 +302,7 @@ function applyComplexity() {
 
 // ── Main entry ────────────────────────────────────────────────────────────────
 function renderGraph(data, isReanalysis = false) {
+  state.layoutStartedAt = Date.now();
   state.graphData = data;
   const projectData = { nodes: data.nodes.filter(n => !n.isLibrary), edges: data.edges.filter(e => !e.isLibraryEdge) };
   state.importanceScores = computeImportanceScores(projectData);

--- a/src/webview/rendering.js
+++ b/src/webview/rendering.js
@@ -271,10 +271,16 @@ function ticked() {
     this.setAttribute('y', d.y + nodeRadius(d) + 10);
   });
 
-  // Auto-fit once after initial settling
-  if (!state.hasFitted && state.simulation && state.simulation.alpha() < 0.1) {
-    state.hasFitted = true;
-    fitToView();
+  // Auto-fit once after initial settling; large graphs also freeze once settled.
+  if (state.simulation) {
+    const alpha = state.simulation.alpha();
+    if (!state.hasFitted && alpha < 0.1) {
+      state.hasFitted = true;
+      fitToView();
+    }
+    if (shouldFreeze(alpha, state.currentNodes.length)) {
+      state.simulation.stop();
+    }
   }
 
   if (state.viewMode === 'workflow') { updateWorkflowDivider(); }
@@ -559,6 +565,7 @@ function startSimulation(allLinks) {
     return;
   }
   if (state.simulation) state.simulation.stop();
+  const n = state.currentNodes.length;
   const svgEl = svg.node();
   const W = svgEl.clientWidth || window.innerWidth;
   const H = svgEl.clientHeight || window.innerHeight;
@@ -575,10 +582,14 @@ function startSimulation(allLinks) {
     .force('center', d3.forceCenter(W / 2, H / 2).strength(0.001))
     .force('x', d3.forceX(W / 2).strength(settings.centerForce))
     .force('y', d3.forceY(H / 2).strength(settings.centerForce))
-    .force('collision', d3.forceCollide(d => nodeRadius(d) + 1))
     .velocityDecay(0.3)
-    .alphaDecay(0.02)
+    .alphaDecay(alphaDecayFor(n))
     .on('tick', ticked);
+  // Collision resolution is skipped for large graphs (it dominates tick cost);
+  // applied via simulation.force() after construction, the idiomatic d3 way.
+  if (useCollide(n)) {
+    state.simulation.force('collision', d3.forceCollide(d => nodeRadius(d) + 1));
+  }
 }
 
 const WORKFLOW_MARGIN_X = 90;

--- a/src/webview/rendering.js
+++ b/src/webview/rendering.js
@@ -570,6 +570,15 @@ function startSimulation(allLinks) {
   }
   if (state.simulation) state.simulation.stop();
   const n = state.currentNodes.length;
+  // Dynamic per-repo force defaults (#27): unless the user hand-tuned the force
+  // sliders, seed centering/repel from the graph size before building forces
+  // (the charge/x/y forces below read settings.* for this repo).
+  if (!settings.userTunedForces) {
+    const defaults = computeForceDefaults(n);
+    settings.centerForce = defaults.centerForce;
+    settings.repelForce = defaults.repelForce;
+    if (typeof syncForceSliders === 'function') syncForceSliders();
+  }
   const svgEl = svg.node();
   const W = svgEl.clientWidth || window.innerWidth;
   const H = svgEl.clientHeight || window.innerHeight;

--- a/src/webview/rendering.js
+++ b/src/webview/rendering.js
@@ -234,6 +234,15 @@ const drag = d3.drag()
     window.markDirty?.();
   });
 
+// Report webview layout settle time back to the host once per render. Guarded on
+// layoutStartedAt so repaint-only ticked() calls (drag, zoom) never re-post.
+function postLayoutMetrics() {
+  if (state.layoutStartedAt == null) { return; }
+  const ms = Date.now() - state.layoutStartedAt;
+  state.layoutStartedAt = null;
+  vscode.postMessage({ type: 'layout-metrics', ms, nodes: state.currentNodes.length });
+}
+
 // ── Tick ──────────────────────────────────────────────────────────────────────
 function ticked() {
   state.svgLinks?.each(function (d) {
@@ -281,6 +290,7 @@ function ticked() {
     if (!state.hasFitted && alpha < 0.1) {
       state.hasFitted = true;
       fitToView();
+      postLayoutMetrics();
     }
     if (shouldFreeze(alpha, state.currentNodes.length)) {
       state.simulation.stop();

--- a/src/webview/rendering.js
+++ b/src/webview/rendering.js
@@ -205,7 +205,10 @@ function fitToView() {
 // ── Drag (swimming effect) ────────────────────────────────────────────────────
 const drag = d3.drag()
   .on('start', (event, d) => {
-    if (state.layoutMode === 'dynamic' && !event.active && state.simulation)
+    // Large graphs freeze once settled (issue #52): don't reheat the whole
+    // simulation for a single drag — move the node directly instead.
+    if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)
+        && !event.active && state.simulation)
       state.simulation.alphaTarget(0.3).restart();
     d.fx = d.x;
     d.fy = d.y;
@@ -213,20 +216,21 @@ const drag = d3.drag()
   .on('drag', (event, d) => {
     d.fx = event.x;
     d.fy = event.y;
-    if (state.layoutMode === 'static') {
-      // Simulation stopped — sync x/y directly so ticked() renders correctly
+    if (state.layoutMode === 'static' || !dragShouldReheat(state.currentNodes.length)) {
+      // Simulation stopped (static, or frozen large graph) — sync x/y directly
+      // so ticked() renders correctly.
       d.x = event.x;
       d.y = event.y;
       ticked();
     }
   })
   .on('end', (event, d) => {
-    if (state.layoutMode === 'dynamic') {
+    if (state.layoutMode === 'dynamic' && dragShouldReheat(state.currentNodes.length)) {
       if (!event.active && state.simulation) state.simulation.alphaTarget(0);
       d.fx = null;
       d.fy = null; // release — node rejoins simulation
     }
-    // static: keep fx/fy pinned so node stays exactly where dropped
+    // static or frozen large graph: keep fx/fy pinned so node stays where dropped
     window.markDirty?.();
   });
 

--- a/src/webview/state.js
+++ b/src/webview/state.js
@@ -27,6 +27,7 @@ const state = {
   currentNodes: [],
   currentZoom: 1,
   hasFitted: false,
+  layoutStartedAt: null,           // Date.now() at renderGraph entry; nulled once metrics posted
   pendingReheat: false,
   layoutMode: 'dynamic',
   gitMode: true,

--- a/src/webview/workflow.js
+++ b/src/webview/workflow.js
@@ -100,6 +100,23 @@ function deriveWorkflowView(data, level) {
   return { nodeToCluster, clusterMembers, clusterLabels, layout, stageCount, dividerStage };
 }
 
+/**
+ * Largest detail level <= `level` whose derived view renders at most `maxNodes`
+ * rendered nodes (issue #52 item 2: the workflow view must stay bounded on huge
+ * repos, since the >=500-node complexity auto-cap excludes it). The rendered-node
+ * count is `clusterMembers.size` — the distinct nodes buildClusteredElements
+ * draws. Level 0 is always allowed (there is no lower level), so the loop
+ * terminates; small graphs whose highest level already fits are left untouched.
+ */
+function clampWorkflowLevel(data, level, maxNodes) {
+  let lvl = level;
+  while (lvl > 0) {
+    if (deriveWorkflowView(data, lvl).clusterMembers.size <= maxNodes) { break; }
+    lvl -= 1;
+  }
+  return lvl;
+}
+
 function cellKey(n) { return 'cell|' + wfStage(n) + '|' + wfTier(n); }
 
 function groupLabel(key, members, nodeById, lvl) {
@@ -135,5 +152,5 @@ function computeColumnX(stage, stageCount, width, marginX) {
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 if (typeof module !== 'undefined') {
-  module.exports = { deriveWorkflowView, computeColumnX, WORKFLOW_LEVELS };
+  module.exports = { deriveWorkflowView, clampWorkflowLevel, computeColumnX, WORKFLOW_LEVELS };
 }

--- a/src/webviewHtmlBuilder.ts
+++ b/src/webviewHtmlBuilder.ts
@@ -155,6 +155,7 @@ export function getWebviewHtml(
   const timelineMode = opts.timelineMode === true;
   const webviewDir = vscode.Uri.joinPath(extensionUri, 'src', 'webview');
   const stateUri     = webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'state.js'));
+  const layoutTuningUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'layoutTuning.js'));
   const aggregateUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'aggregate.js'));
   const clusteringUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'clustering.js'));
   const workflowUri  = webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'workflow.js'));
@@ -401,6 +402,7 @@ export function getWebviewHtml(
     <ul id="ctx-menu-list"></ul>
   </div>
   <script nonce="${nonce}" src="${stateUri}"></script>
+  <script nonce="${nonce}" src="${layoutTuningUri}"></script>
   <script nonce="${nonce}" src="${aggregateUri}"></script>
   <script nonce="${nonce}" src="${clusteringUri}"></script>
   <script nonce="${nonce}" src="${workflowUri}"></script>


### PR DESCRIPTION
Closes #52. Closes #27. Advances #50 (Approach 3.1 — issue stays open for the remaining approaches).

## Problem

CoGraph feels slow and janky on large repositories (#50): the force layout takes a long time to settle, pan/zoom/drag stutter while it does, and dragging one node reheats the whole graph (#52). Force defaults are one-size-fits-all regardless of repo size (#27), and there is no timing output to tell a slow run from a hung one (#50, Approach 3.1).

## Changes

**Force layout at scale (#52)** — new pure module `src/webview/layoutTuning.js` holds all size-based decisions; consumers only call through it:
- Large graphs (≥800 rendered nodes) settle fast (`alphaDecay` 0.05) and **freeze** (`simulation.stop()`) once alpha < 0.05 — no more endless low-energy ticking. Every reheat path (`restart()`) still works.
- Dragging on a large graph pins and moves the node(s) directly (same as static-layout mode) instead of `alphaTarget(0.3).restart()` re-agitating everything — applied across all 7 drag handlers (rendering/folder/class).
- `forceCollide` (the most expensive force) is dropped above the threshold.
- The workflow view detail level is clamped so it never renders more than 400 nodes (it was excluded from the ≥500-node complexity auto-cap).

**Dynamic per-repo force defaults (#27)** — `computeForceDefaults(nodeCount)` interpolates centerForce 0.05→0.15 and repelForce 250→80 between 500 and 3000 nodes; applied at simulation build unless the user has touched a force slider (`userTunedForces`), synced to the sliders, and used by Reset Layout. Also fixes the init inconsistency where `centerForce` started at 0.025 but slider/reset said 0.05.

**Instrumentation (#50 Approach 3.1)** — `[perf]` lines in the CoGraph output channel: per-analyzer wall time + attempt totals, merged payload size (nodes/edges/KB-MB), and a new `layout-metrics` webview→host message reporting layout settle time.

**Small-graph invariance:** below the thresholds nothing changes except the deliberate centerForce init fix. Verified per task and in the whole-branch review.

## Testing

- 671 tests passing (9 new: layoutTuning unit suite, dynamic-defaults controls suite, workflow clamp, analyzer timing, payload/layout metrics), lint 0 errors.
- Every task was implemented TDD (RED→GREEN evidence in `.superpowers/sdd/` reports) and independently reviewed; a final whole-branch review verified the integration seams (freeze × drag × pendingReheat × graph-loaded × defaults) and found no blocking issues.
- Still needs a **manual smoke test** on a real large repo (all lenses + workflow view) and before/after numbers posted to #52 — the new `[perf]` output channel lines provide the measurements.

## Out of Scope (deliberately)

- #50 Approaches 1 & 2.2–2.4 (incremental analysis cache, Web Worker simulation, canvas fallback, graph-patch deltas) — #50 stays open.
- rAF-throttling of tick→DOM writes: verified moot — d3-force ticks via d3-timer, which is already rAF-driven.
- Persisting user-tuned force values in the save payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2kNtnLGpb1DHvUV5cgFcP
